### PR TITLE
Add GitHub Actions workflow for pre-commit checks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Sets up a workflow to automatically run pre-commit hooks using the repo's pre-commit-config.yaml Workflow runs on pull requests and pushes to the main branch.