### PR TITLE
Separate management and client API authentication

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -90,6 +90,7 @@ jobs:
           APP_ENV: "production"
           DEBUG: "false"
           TAS_API_KEY: "our-secure-api-key-asdfg-12345-zxcvb-qwerty-lkjhg-56789-a1s23-56"
+          TAS_MANAGEMENT_API_KEY:  "mgmt-our-secure-api-key-asdfg-12345-zxcvb-qwerty-lkjhg-56789-a1s23-56"
       
       - name: run application for 1 second with gunicorn
         run: |
@@ -107,3 +108,4 @@ jobs:
           APP_ENV: "production"
           DEBUG: "false"
           TAS_API_KEY: "our-secure-api-key-asdfg-12345-zxcvb-qwerty-lkjhg-56789-a1s23-56"
+          TAS_MANAGEMENT_API_KEY: "mgmt-our-secure-api-key-asdfg-12345-zxcvb-qwerty-lkjhg-56789-a1s23-56"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ redis-server &
 
 # 4. Set environment variables
 export TAS_API_KEY="your-64-character-api-key-here-make-it-secure-and-long-enough"
+export TAS_MANAGEMENT_API_KEY="your-64-character-management-key-here-different-from-api-key"
 export TAS_KBM_PLUGIN="tas_kbm_mock"  # Use mock plugin for testing
 
 # 5. Create and sign TAS policy
@@ -138,7 +139,8 @@ cd ..
 
 #### Option A: Quick Setup (Mock KBM)
 ```bash
-export TAS_API_KEY="$(openssl rand -hex 32)"  # Generate secure API key
+export TAS_API_KEY="$(openssl rand -hex 32)"  # Generate secure client API key
+export TAS_MANAGEMENT_API_KEY="$(openssl rand -hex 32)"  # Generate secure management API key
 export TAS_KBM_PLUGIN="tas_kbm_mock"
 echo "secrets:\n  test-key-1: test-secret-value" > config/mock_secrets.yaml
 export TAS_KBM_CONFIG_FILE="config/mock_secrets.yaml"
@@ -146,7 +148,8 @@ export TAS_KBM_CONFIG_FILE="config/mock_secrets.yaml"
 
 #### Option B: Production Setup (KMIP JSON KBM)
 ```bash
-export TAS_API_KEY="$(openssl rand -hex 32)"  # Generate secure API key
+export TAS_API_KEY="$(openssl rand -hex 32)"  # Generate secure client API key
+export TAS_MANAGEMENT_API_KEY="$(openssl rand -hex 32)"  # Generate secure management API key
 export TAS_KBM_PLUGIN="tas_kbm_kmip_json"
 export TAS_KBM_CONFIG_FILE="./config/kmip/kmip.conf"
 
@@ -279,6 +282,7 @@ TAS uses a flexible configuration system supporting environment variables and YA
 ```bash
 # Minimum required configuration
 export TAS_API_KEY="your-secure-64-character-minimum-api-key-here"
+export TAS_MANAGEMENT_API_KEY="your-secure-64-character-minimum-management-key"
 export TAS_KBM_PLUGIN="tas_kbm_mock"  # or "tas_kbm_kmip"
 ```
 
@@ -287,6 +291,7 @@ export TAS_KBM_PLUGIN="tas_kbm_mock"  # or "tas_kbm_kmip"
 ```bash
 # Core settings
 export TAS_API_KEY="your-production-api-key-must-be-64-characters-minimum"
+export TAS_MANAGEMENT_API_KEY="your-management-api-key-must-be-64-characters-min"
 export TAS_KBM_PLUGIN="tas_kbm_kmip"
 export TAS_KBM_CONFIG_FILE="./config/pykmip/pykmip.conf"
 
@@ -320,21 +325,43 @@ curl -H "X-API-KEY: your-api-key" http://localhost:5000/version
 
 ### Core Endpoints
 
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/kb/v0/get_nonce` | GET | Generate attestation nonce |
-| `/kb/v0/get_secret` | POST | Retrieve secret after TEE verification |
-| `/policy/v0/store` | POST | Store security policy |
-| `/policy/v0/get/<key>` | GET | Retrieve security policy |
-| `/policy/v0/list` | GET | List all policies |
-| `/policy/v0/delete/<key>` | DELETE | Delete security policy |
-| `/version` | GET | Get TAS version |
+| Endpoint | Method | Auth Header | Description |
+|----------|--------|-------------|-------------|
+| `/kb/v0/get_nonce` | GET | `X-API-KEY` | Generate attestation nonce |
+| `/kb/v0/get_secret` | POST | `X-API-KEY` | Retrieve secret after TEE verification |
+| `/version` | GET | `X-API-KEY` | Get TAS version |
+
+### Management Endpoints
+
+| Endpoint | Method | Auth Header | Description |
+|----------|--------|-------------|-------------|
+| `/management/policy/v0/store` | POST | `X-MANAGEMENT-API-KEY` | Store security policy |
+| `/management/policy/v0/get/<key>` | GET | `X-MANAGEMENT-API-KEY` | Retrieve security policy |
+| `/management/policy/v0/list` | GET | `X-MANAGEMENT-API-KEY` | List all policies |
+| `/management/policy/v0/delete/<key>` | DELETE | `X-MANAGEMENT-API-KEY` | Delete security policy |
+
+### Deprecated Endpoints
+
+> **Deprecated**: The `/policy/v0/*` endpoints below are deprecated and will be removed after **31 March 2026**.
+> Use the `/management/policy/v0/*` endpoints above instead. Deprecated responses include `Deprecation`, `Sunset`, and `Warning` headers per [RFC 8594](https://www.rfc-editor.org/rfc/rfc8594).
+
+| Endpoint | Method | Auth Header | Description |
+|----------|--------|-------------|-------------|
+| `/policy/v0/store` | POST | `X-MANAGEMENT-API-KEY` | ~~Store security policy~~ (use `/management/policy/v0/store`) |
+| `/policy/v0/get/<key>` | GET | `X-MANAGEMENT-API-KEY` | ~~Retrieve security policy~~ (use `/management/policy/v0/get/<key>`) |
+| `/policy/v0/list` | GET | `X-MANAGEMENT-API-KEY` | ~~List all policies~~ (use `/management/policy/v0/list`) |
+| `/policy/v0/delete/<key>` | DELETE | `X-MANAGEMENT-API-KEY` | ~~Delete security policy~~ (use `/management/policy/v0/delete/<key>`) |
 
 ### Authentication
 
-All endpoints require API key authentication:
+TAS uses separate API keys for client and management operations:
+
 ```bash
+# Client endpoints (attestation, key retrieval)
 curl -H "X-API-KEY: your-api-key" <endpoint>
+
+# Management endpoints (policy CRUD)
+curl -H "X-MANAGEMENT-API-KEY: your-management-key" <endpoint>
 ```
 
 ### Example API Usage
@@ -364,7 +391,7 @@ curl -X POST \
 ```bash
 curl -X POST \
   -H "Content-Type: application/json" \
-  -H "X-API-KEY: your-api-key" \
+  -H "X-MANAGEMENT-API-KEY: your-management-key" \
   -d '{
     "policy_type": "SEV",
     "key_id": "my-key-1",
@@ -377,7 +404,7 @@ curl -X POST \
       }
     }
   }' \
-  http://localhost:5000/policy/v0/store
+  http://localhost:5000/management/policy/v0/store
 ```
 
 **Complete API Documentation**: See [docs/openapi.yaml](docs/openapi.yaml) and [docs/openapi.json](docs/openapi.json) files
@@ -524,6 +551,7 @@ python -m pytest tests/ --cov=tas --cov-report=html
  - Add RSA key to TEE report data
  - Policy registering tool
  - Policy identifier changes
+ - **Removal of deprecated `/policy/v0/*` endpoints** (31 March 2026) — migrate to `/management/policy/v0/*`
 
 ## Contributing 
 
@@ -545,9 +573,10 @@ redis-cli ping  # Test connectivity
 ```
 Error: TAS_API_KEY environment variable is not set
 ```
-**Solution**: Set a secure API key (minimum 64 characters)
+**Solution**: Set secure API keys (minimum 64 characters each)
 ```bash
 export TAS_API_KEY="$(openssl rand -hex 32)"
+export TAS_MANAGEMENT_API_KEY="$(openssl rand -hex 32)"
 ```
 
 ### KMIP Connection Issues

--- a/app.py
+++ b/app.py
@@ -20,12 +20,10 @@ import time
 import redis
 from flask import Flask, jsonify, request
 
+from tas.auth import authenticate_request, init_client_auth, init_management_auth
 from tas.config_loader import load_configuration
-from tas.policy_helper import (
-    POLICY_KEY_COMPONENT_RE,
-    validate_policy_key,
-    verify_policy_signature,
-)
+from tas.deprecated_routes import deprecated_policy_bp
+from tas.management_routes import management_bp
 from tas.tas_logging import configure_external_logging, setup_logging
 from tas.tas_vm import vm_verify
 
@@ -38,6 +36,10 @@ logger.debug("Loading in config")
 
 # Load configuration
 load_configuration(app)
+
+# Initialise authentication
+init_client_auth(app)
+init_management_auth(app)
 
 # Reconfigure logging with settings from config if available
 tas_config = app.config.get("TAS", {})
@@ -151,6 +153,13 @@ except redis.ConnectionError as e:
 except Exception as e:
     raise RuntimeError(f"An unexpected error occurred while initializing Redis: {e}")
 
+# Expose Redis client to blueprints
+app.extensions["redis"] = redis_client
+
+# Register blueprints
+app.register_blueprint(management_bp)
+app.register_blueprint(deprecated_policy_bp)
+
 # log discovered plugins for debugging
 logger.debug("Discovered plugins:")
 tas_kbm_plugin = None
@@ -218,16 +227,6 @@ def validate_nonce(nonce):
     logger.debug("Nonce validation successful, removing from Redis")
     redis_client.delete(nonce)  # Remove nonce after successful validation
     return True, None
-
-
-# Function to check API key
-def authenticate_request():
-    api_key = request.headers.get("X-API-KEY")
-    if api_key != TAS_API_KEY:
-        logger.warning(
-            f"Unauthorized request from {request.remote_addr}: Invalid API key"
-        )
-        return jsonify({"error": "Unauthorized"}), 401
 
 
 # Endpoint to generate and send a nonce
@@ -342,285 +341,6 @@ def get_secret():
     # Return the secret
     logger.info(f"Successfully completed secret request for {request.remote_addr}")
     return jsonify({"secret_key": secret})
-
-
-# Endpoint to store a policy in Redis
-@app.route("/policy/v0/store", methods=["POST"])
-def store_policy():
-    """
-    Store a security policy in Redis for later use in attestation validation.
-
-    Expected JSON payload:
-    {
-        "policy_type": "SEV|TDX",
-        "key_id": "my-key-1",
-        "policy": {
-            "metadata": {
-                "name": "My Security Policy",
-                "version": "1.0",
-                "description": "Custom security policy"
-            },
-            "validation_rules": {
-                "host_data": {
-                    "exact_match": "..."
-                },
-                "policy": {
-                    "debug_allowed": false,
-                    "migrate_ma_allowed": false
-                }
-            }
-        }
-    }
-    """
-    logger.info(f"Received policy store request from {request.remote_addr}")
-    auth_response = authenticate_request()
-    if auth_response:
-        return auth_response
-
-    # Get the JSON data from the request
-    data = request.get_json()
-    if not data:
-        logger.error("Policy store request missing JSON body")
-        return jsonify({"error": "Request body is required"}), 400
-
-    # Validate required fields
-    policy_type = data.get("policy_type")
-    if not policy_type:
-        logger.error("Policy store request missing policy_type")
-        return jsonify({"error": "Policy type is required (e.g. SEV, TDX)"}), 400
-
-    if not POLICY_KEY_COMPONENT_RE.match(str(policy_type)):
-        logger.error(f"Invalid policy_type: {policy_type}")
-        return (
-            jsonify(
-                {
-                    "error": "Invalid policy_type. Use only alphanumeric characters, hyphens, underscores, and dots"
-                }
-            ),
-            400,
-        )
-
-    key_id = data.get("key_id")
-    if not key_id:
-        logger.error("Policy store request missing key_id")
-        return jsonify({"error": "Key ID is required"}), 400
-
-    if not POLICY_KEY_COMPONENT_RE.match(str(key_id)):
-        logger.error(f"Invalid key_id: {key_id}")
-        return (
-            jsonify(
-                {
-                    "error": "Invalid key_id. Use only alphanumeric characters, hyphens, underscores, and dots"
-                }
-            ),
-            400,
-        )
-
-    policy = data.get("policy")
-    if not policy:
-        logger.error("Policy store request missing policy data")
-        return jsonify({"error": "Policy data is required"}), 400
-
-    # Validate policy structure
-    if not isinstance(policy, dict):
-        logger.error("Policy data is not a valid JSON object")
-        return jsonify({"error": "Policy must be a JSON object"}), 400
-
-    # Check for required policy sections
-    if "metadata" not in policy:
-        logger.error("Policy missing required 'metadata' section")
-        return jsonify({"error": "Policy must contain 'metadata' section"}), 400
-
-    if "validation_rules" not in policy:
-        logger.error("Policy missing required 'validation_rules' section")
-        return jsonify({"error": "Policy must contain 'validation_rules' section"}), 400
-
-    # Check if policy is signed
-    is_signed = "signature" in policy
-    warning_message = None
-    if not is_signed:
-        logger.warning(f"Policy {policy_type}:{key_id} is not signed")
-        warning_message = (
-            "WARNING: Policy is not signed and cannot be verified for integrity"
-        )
-        if app.config.get("TAS_ENFORCE_SIGNED_POLICIES", True):
-            logger.error("Unsigned policies are not allowed by configuration")
-            return (
-                jsonify(
-                    {"error": "Unsigned policies are not allowed by configuration"}
-                ),
-                400,
-            )
-    else:
-        logger.info(f"Policy {policy_type}:{key_id} is signed")
-        # If the policy is signed, verify the signature unless enforcement is disabled in config
-        # Note: Even if the policy is signed, but TAS_ENFORCE_SIGNED_POLICIES is False, we will
-        # allow it but log a warning that signature verification is not enforced.
-        if not app.config.get("TAS_ENFORCE_SIGNED_POLICIES", True):
-            logger.warning(
-                "Signed policy not verified - policy signature check is disabled"
-            )
-            warning_message = "WARNING: Signed policy not verified - policy signature check is disabled"
-        else:
-            if not verify_policy_signature(
-                policy, app.config.get("TAS_TRUSTED_KEYS", [])
-            ):
-                logger.error("Policy signature verification failed")
-                return jsonify({"error": "Policy signature verification failed"}), 400
-            logger.info("Policy signature verification successful")
-
-    try:
-        # Store the policy in Redis with a descriptive key
-        policy_key = f"policy:{policy_type}:{key_id}"
-        policy_json = json.dumps(policy)
-
-        # Store with no expiration (policies should persist)
-        redis_client.set(policy_key, policy_json)
-
-        logger.info(f"Stored policy '{policy_key}' in Redis")
-
-        response_data = {"message": f"Policy '{policy_key}' stored successfully"}
-        if warning_message:
-            response_data["warning"] = warning_message
-
-        return jsonify(response_data), 201
-
-    except Exception as e:
-        logger.error(f"Error storing policy: {e}")
-        return jsonify({"error": "Failed to store policy in Redis"}), 500
-
-
-# Endpoint to retrieve a policy from Redis
-@app.route("/policy/v0/get/<policy_key>", methods=["GET"])
-def get_policy(policy_key):
-    """
-    Retrieve a security policy from Redis.
-    """
-    logger.info(
-        f"Received policy get request for '{policy_key}' from {request.remote_addr}"
-    )
-    auth_response = authenticate_request()
-    if auth_response:
-        return auth_response
-
-    # Validate the policy key format
-    is_valid, error_message = validate_policy_key(policy_key)
-    if not is_valid:
-        logger.error(f"Invalid policy key '{policy_key}': {error_message}")
-        return jsonify({"error": error_message}), 400
-
-    try:
-        # Retrieve the policy from Redis
-        logger.debug(f"Retrieving policy '{policy_key}' from Redis")
-        policy_json = redis_client.get(policy_key)
-
-        if not policy_json:
-            logger.warning(f"Policy '{policy_key}' not found in Redis")
-            return jsonify({"error": f"Policy '{policy_key}' not found"}), 404
-
-        policy = json.loads(policy_json)
-        logger.info(f"Successfully retrieved policy '{policy_key}'")
-
-        # Check if policy is signed and add warning if not
-        response_data = {"policy_key": policy_key, "policy": policy}
-        if "signature" not in policy:
-            logger.warning(f"Retrieved policy '{policy_key}' is not signed")
-            response_data[
-                "warning"
-            ] = "WARNING: Policy is not signed and cannot be verified for integrity"
-
-        return jsonify(response_data), 200
-
-    except json.JSONDecodeError as e:
-        logger.error(f"Error parsing policy JSON: {e}")
-        return jsonify({"error": "Invalid policy data in Redis"}), 500
-    except Exception as e:
-        logger.error(f"Error retrieving policy: {e}")
-        return jsonify({"error": "Failed to retrieve policy from Redis"}), 500
-
-
-# Endpoint to list all stored policies
-@app.route("/policy/v0/list", methods=["GET"])
-def list_policies():
-    """
-    List all stored policies in Redis.
-    """
-    logger.info(f"Received policy list request from {request.remote_addr}")
-    auth_response = authenticate_request()
-    if auth_response:
-        return auth_response
-
-    try:
-        # Get all policy keys from Redis
-        logger.debug("Retrieving all policy keys from Redis")
-        policy_keys = redis_client.keys("policy:*")
-        logger.debug(f"Found {len(policy_keys)} policy keys in Redis")
-
-        policies = []
-        for key in policy_keys:
-            policy_json = redis_client.get(key)
-
-            if policy_json:
-                try:
-                    policy = json.loads(policy_json)
-                    metadata = policy.get("metadata", {})
-                    policy_info = {
-                        "policy_key": key,
-                        "name": metadata.get("name", "Unknown"),
-                        "version": metadata.get("version", "Unknown"),
-                        "description": metadata.get("description", "No description"),
-                        "signed": "signature" in policy,
-                    }
-                    policies.append(policy_info)
-                    logger.debug(f"Added policy to list: {key}")
-                except json.JSONDecodeError:
-                    # Skip invalid policies
-                    logger.warning(f"Skipping invalid policy with key: {key}")
-                    continue
-
-        logger.info(f"Successfully listed {len(policies)} policies")
-        return jsonify({"policies": policies, "count": len(policies)}), 200
-
-    except Exception as e:
-        logger.error(f"Error listing policies: {e}")
-        return jsonify({"error": "Failed to list policies"}), 500
-
-
-# Endpoint to delete a policy from Redis
-@app.route("/policy/v0/delete/<policy_key>", methods=["DELETE"])
-def delete_policy(policy_key):
-    """
-    Delete a security policy from Redis.
-    """
-    logger.info(
-        f"Received policy delete request for '{policy_key}' from {request.remote_addr}"
-    )
-    auth_response = authenticate_request()
-    if auth_response:
-        return auth_response
-
-    # Validate the policy key format
-    is_valid, error_message = validate_policy_key(policy_key)
-    if not is_valid:
-        logger.error(f"Invalid policy key '{policy_key}': {error_message}")
-        return jsonify({"error": error_message}), 400
-
-    try:
-        # Delete the policy from Redis
-        logger.debug(f"Attempting to delete policy with key: {policy_key}")
-        deleted_count = redis_client.delete(policy_key)
-
-        if deleted_count == 0:
-            logger.warning(f"Policy '{policy_key}' not found for deletion")
-            return jsonify({"error": f"Policy '{policy_key}' not found"}), 404
-
-        logger.info(f"Deleted policy '{policy_key}' from Redis")
-
-        return jsonify({"message": f"Policy '{policy_key}' deleted successfully"}), 200
-
-    except Exception as e:
-        logger.error(f"Error deleting policy: {e}")
-        return jsonify({"error": "Failed to delete policy from Redis"}), 500
 
 
 # Endpoint to retrieve the version information

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -28,6 +28,7 @@ export TAS_CONFIG_CLASS=config.ProductionConfig
 - Use the exact key name; examples:
 ```bash
 export TAS_API_KEY='replace-with-a-strong-key-at-least-64-chars'
+export TAS_MANAGEMENT_API_KEY='replace-with-a-strong-management-key-64-chars'
 export TAS_NONCE_EXPIRATION_SECONDS=180
 export TAS_REDIS_HOST='redis.internal'
 export TAS_REDIS_PORT=6380
@@ -118,6 +119,8 @@ Stored in Flask's config; set directly via env without prefix:
 | TAS_VERSION | str | `"0.1.0"` | No | Application version string returned by the `/version` endpoint. |
 | TAS_API_KEY | str | `""` | **Yes** | Shared secret used to authenticate every API request. Must be at least `TAS_API_KEY_MIN_LENGTH` characters long. |
 | TAS_API_KEY_MIN_LENGTH | int | `64` | No | Minimum number of characters required for `TAS_API_KEY`. The application refuses to start if the API key is shorter than this value. |
+| TAS_MANAGEMENT_API_KEY | str | `""` | **Yes** | Shared secret used to authenticate management API requests (policy CRUD). Must be at least `TAS_MANAGEMENT_API_KEY_MIN_LENGTH` characters long. Sent via the `X-MANAGEMENT-API-KEY` header. |
+| TAS_MANAGEMENT_API_KEY_MIN_LENGTH | int | `64` | No | Minimum number of characters required for `TAS_MANAGEMENT_API_KEY`. The application refuses to start if the management key is shorter than this value. |
 | TAS_NONCE_EXPIRATION_SECONDS | int | `120` | No | Number of seconds a nonce remains valid after creation. Nonces older than this are rejected during attestation verification. |
 | TAS_REDIS_HOST | str | `"localhost"` | No | Hostname or IP address of the Redis server used for nonce storage, certificate caching, and policy storage. |
 | TAS_REDIS_PORT | int | `6379` | No | Port number of the Redis server. |
@@ -151,6 +154,7 @@ These live under `app.config["TAS"]` as a nested dictionary. Set them in the YAM
 ### Validation at startup
 
 - **TAS_API_KEY** is required and must be at least `TAS_API_KEY_MIN_LENGTH` characters long. The application raises a `RuntimeError` and refuses to start otherwise.
+- **TAS_MANAGEMENT_API_KEY** is required and must be at least `TAS_MANAGEMENT_API_KEY_MIN_LENGTH` characters long. The application raises a `RuntimeError` and refuses to start otherwise.
 - **TAS_POLICY_TRUST**, if set, must point to a path containing at least one valid PEM certificate. If no valid keys can be loaded and signed-policy enforcement is enabled, the application raises a `RuntimeError`.
 - **TAS_ENFORCE_SIGNED_POLICIES** defaults to `true`. Setting it to `false` disables all policy signature checks. This means:
   - Unsigned policies are accepted without error.
@@ -178,6 +182,7 @@ export TAS_PLUGIN_PREFIX=tas_kbm
 export TAS_EXTRA_PLUGIN_DIR=/opt/tas/plugins
 export TAS_POLICY_TRUST=./certs/policy
 export TAS_API_KEY='...(>=64 chars)...'
+export TAS_MANAGEMENT_API_KEY='...(>=64 chars)...'
 ```
 
 ## Run TAS with ProductionConfig or DevelopmentConfig
@@ -189,6 +194,7 @@ flask:
 export TAS_CONFIG_CLASS=config.ProductionConfig
 # or: export TAS_CONFIG_CLASS=config.DevelopmentConfig
 export TAS_API_KEY='...>= TAS_API_KEY_MIN_LENGTH...'
+export TAS_MANAGEMENT_API_KEY='...>= TAS_MANAGEMENT_API_KEY_MIN_LENGTH...'
 flask run -h 0.0.0.0 -p 5000
 ```
 
@@ -196,6 +202,7 @@ gunicorn:
 ```bash
 export TAS_CONFIG_CLASS=config.ProductionConfig
 export TAS_API_KEY='...'
+export TAS_MANAGEMENT_API_KEY='...'
 gunicorn -w 4 -b 0.0.0.0:5000 app:app
 ```
 

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -22,6 +22,10 @@ TAS policies define the security requirements that TEE attestation evidence must
 
 Policies are stored in Redis and referenced during attestation validation to determine if TEE evidence meets the required security standards.
 
+> **Deprecation Notice**: The `/policy/v0/*` endpoints are deprecated and will be removed after **31 March 2026**.
+> All policy management operations should use the new `/management/policy/v0/*` endpoints with the `X-MANAGEMENT-API-KEY` header.
+> See the [Registering Policies](#registering-policies) section for updated examples.
+
 ## Policy Structure
 
 ### Example Policy Format
@@ -209,6 +213,8 @@ python3 demo_signer.py --cert your-policy.json
 
 To register a policy with TAS, you must wrap your **signed policy from the previous step** in a registration payload. This payload specifies the policy type and associates it with a secret ID.
 
+Policy registration uses the **management API**, which requires the `X-MANAGEMENT-API-KEY` header (separate from the client `X-API-KEY`).
+
 ### Registration Payload Format
 
 **Important:** The `policy` field contains your complete signed policy from Step 2 above (including metadata, validation_rules, and signature).
@@ -260,13 +266,13 @@ Example: `policy:SEV:my-secret-id`
 ### Using curl
 
 ```bash
-# Set your API key
-export TAS_API_KEY="your-api-key-here"
+# Set your management API key
+export TAS_MANAGEMENT_API_KEY="your-management-api-key-here"
 
-# Register the signed policy
-curl -X POST http://localhost:5001/policy/v0/store \
+# Register the signed policy (management API)
+curl -X POST http://localhost:5001/management/policy/v0/store \
   -H "Content-Type: application/json" \
-  -H "X-API-KEY: $TAS_API_KEY" \
+  -H "X-MANAGEMENT-API-KEY: $TAS_MANAGEMENT_API_KEY" \
   -d  '{
     "policy_type": "SEV",
     "key_id": "...",
@@ -396,9 +402,9 @@ Error: Policy must contain 'validation_rules' section
 # Verify policy syntax
 python3 -m json.tool my-policy.json
 
-# List registered policies
-curl -H "X-API-KEY: $TAS_API_KEY" http://localhost:5001/policy/v0/list
+# List registered policies (management API)
+curl -H "X-MANAGEMENT-API-KEY: $TAS_MANAGEMENT_API_KEY" http://localhost:5001/management/policy/v0/list
 
-# Get specific policy
-curl -H "X-API-KEY: $TAS_API_KEY" http://localhost:5001/policy/v0/get/policy:SNP:my-policy-id
+# Get specific policy (management API)
+curl -H "X-MANAGEMENT-API-KEY: $TAS_MANAGEMENT_API_KEY" http://localhost:5001/management/policy/v0/get/policy:SNP:my-policy-id
 ```

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -27,6 +27,12 @@
         "in": "header",
         "name": "X-API-KEY",
         "description": "API key for authentication"
+      },
+      "ManagementApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-MANAGEMENT-API-KEY",
+        "description": "Management API key for policy administration"
       }
     },
     "schemas": {
@@ -250,6 +256,34 @@
           "version"
         ]
       }
+    },
+    "headers": {
+      "Deprecation": {
+        "description": "Indicates the endpoint is deprecated (RFC 8594)",
+        "schema": {
+          "type": "string",
+          "example": "true"
+        }
+      },
+      "Sunset": {
+        "description": "Date after which the endpoint will be removed (RFC 8594, RFC 7231 IMF-fixdate)",
+        "schema": {
+          "type": "string",
+          "example": "Tue, 31 Mar 2026 23:59:59 GMT"
+        }
+      },
+      "Link": {
+        "description": "Link to the replacement endpoint",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Warning": {
+        "description": "Human-readable deprecation warning",
+        "schema": {
+          "type": "string"
+        }
+      }
     }
   },
   "paths": {
@@ -358,13 +392,465 @@
     "/policy/v0/store": {
       "post": {
         "tags": [
+          "Policy Management (Deprecated)"
+        ],
+        "summary": "Store a security policy",
+        "description": "Stores a security policy for later use in attestation validation Deprecated: will be removed after 31 March 2026. Use /management/policy/v0/* endpoints instead.",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PolicyStoreRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Policy stored successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "warning": {
+                      "type": "string"
+                    },
+                    "deprecation_warning": {
+                      "type": "string",
+                      "description": "Deprecation notice for this endpoint"
+                    }
+                  }
+                }
+              }
+            },
+            "headers": {
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              },
+              "Link": {
+                "$ref": "#/components/headers/Link"
+              },
+              "Warning": {
+                "$ref": "#/components/headers/Warning"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - Invalid policy data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "headers": {
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              },
+              "Link": {
+                "$ref": "#/components/headers/Link"
+              },
+              "Warning": {
+                "$ref": "#/components/headers/Warning"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "headers": {
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              },
+              "Link": {
+                "$ref": "#/components/headers/Link"
+              },
+              "Warning": {
+                "$ref": "#/components/headers/Warning"
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/policy/v0/get/{policy_key}": {
+      "get": {
+        "tags": [
+          "Policy Management (Deprecated)"
+        ],
+        "summary": "Get a security policy",
+        "description": "Retrieves a stored security policy by key Deprecated: will be removed after 31 March 2026. Use /management/policy/v0/* endpoints instead.",
+        "security": [
+          {
+            "ManagementApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "policy_key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Policy key to retrieve"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Policy retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "policy_key": {
+                      "type": "string"
+                    },
+                    "policy": {
+                      "$ref": "#/components/schemas/PolicyData"
+                    },
+                    "warning": {
+                      "type": "string"
+                    },
+                    "deprecation_warning": {
+                      "type": "string",
+                      "description": "Deprecation notice for this endpoint"
+                    }
+                  }
+                }
+              }
+            },
+            "headers": {
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              },
+              "Link": {
+                "$ref": "#/components/headers/Link"
+              },
+              "Warning": {
+                "$ref": "#/components/headers/Warning"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "headers": {
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              },
+              "Link": {
+                "$ref": "#/components/headers/Link"
+              },
+              "Warning": {
+                "$ref": "#/components/headers/Warning"
+              }
+            }
+          },
+          "404": {
+            "description": "Policy not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "headers": {
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              },
+              "Link": {
+                "$ref": "#/components/headers/Link"
+              },
+              "Warning": {
+                "$ref": "#/components/headers/Warning"
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/policy/v0/list": {
+      "get": {
+        "tags": [
+          "Policy Management (Deprecated)"
+        ],
+        "summary": "List all policies",
+        "description": "Lists all stored security policies Deprecated: will be removed after 31 March 2026. Use /management/policy/v0/* endpoints instead.",
+        "security": [
+          {
+            "ManagementApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Policies listed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "policies": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "policy_key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "signed": {
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    },
+                    "count": {
+                      "type": "integer"
+                    },
+                    "deprecation_warning": {
+                      "type": "string",
+                      "description": "Deprecation notice for this endpoint"
+                    }
+                  }
+                }
+              }
+            },
+            "headers": {
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              },
+              "Link": {
+                "$ref": "#/components/headers/Link"
+              },
+              "Warning": {
+                "$ref": "#/components/headers/Warning"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "headers": {
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              },
+              "Link": {
+                "$ref": "#/components/headers/Link"
+              },
+              "Warning": {
+                "$ref": "#/components/headers/Warning"
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/policy/v0/delete/{policy_name}": {
+      "delete": {
+        "tags": [
+          "Policy Management (Deprecated)"
+        ],
+        "summary": "Delete a security policy",
+        "description": "Deletes a stored security policy Deprecated: will be removed after 31 March 2026. Use /management/policy/v0/* endpoints instead.",
+        "security": [
+          {
+            "ManagementApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "policy_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Policy name to delete"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Policy deleted successfully",
+            "headers": {
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              },
+              "Link": {
+                "$ref": "#/components/headers/Link"
+              },
+              "Warning": {
+                "$ref": "#/components/headers/Warning"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "headers": {
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              },
+              "Link": {
+                "$ref": "#/components/headers/Link"
+              },
+              "Warning": {
+                "$ref": "#/components/headers/Warning"
+              }
+            }
+          },
+          "404": {
+            "description": "Policy not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "headers": {
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              },
+              "Link": {
+                "$ref": "#/components/headers/Link"
+              },
+              "Warning": {
+                "$ref": "#/components/headers/Warning"
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/version": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Get TAS version",
+        "description": "Returns the current version of the TEE Attestation Service",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Version information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VersionResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/management/policy/v0/store": {
+      "post": {
+        "tags": [
           "Policy Management"
         ],
         "summary": "Store a security policy",
         "description": "Stores a security policy for later use in attestation validation",
         "security": [
           {
-            "ApiKeyAuth": []
+            "ManagementApiKeyAuth": []
           }
         ],
         "requestBody": {
@@ -407,7 +893,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized",
+            "description": "Unauthorized - Invalid management API key",
             "content": {
               "application/json": {
                 "schema": {
@@ -419,7 +905,7 @@
         }
       }
     },
-    "/policy/v0/get/{policy_key}": {
+    "/management/policy/v0/get/{policy_key}": {
       "get": {
         "tags": [
           "Policy Management"
@@ -428,7 +914,7 @@
         "description": "Retrieves a stored security policy by key",
         "security": [
           {
-            "ApiKeyAuth": []
+            "ManagementApiKeyAuth": []
           }
         ],
         "parameters": [
@@ -487,7 +973,7 @@
         }
       }
     },
-    "/policy/v0/list": {
+    "/management/policy/v0/list": {
       "get": {
         "tags": [
           "Policy Management"
@@ -496,7 +982,7 @@
         "description": "Lists all stored security policies",
         "security": [
           {
-            "ApiKeyAuth": []
+            "ManagementApiKeyAuth": []
           }
         ],
         "responses": {
@@ -551,7 +1037,7 @@
         }
       }
     },
-    "/policy/v0/delete/{policy_name}": {
+    "/management/policy/v0/delete/{policy_key}": {
       "delete": {
         "tags": [
           "Policy Management"
@@ -560,18 +1046,18 @@
         "description": "Deletes a stored security policy",
         "security": [
           {
-            "ApiKeyAuth": []
+            "ManagementApiKeyAuth": []
           }
         ],
         "parameters": [
           {
-            "name": "policy_name",
+            "name": "policy_key",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string"
             },
-            "description": "Policy name to delete"
+            "description": "Policy key to delete"
           }
         ],
         "responses": {
@@ -590,42 +1076,6 @@
           },
           "404": {
             "description": "Policy not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/version": {
-      "get": {
-        "tags": [
-          "System"
-        ],
-        "summary": "Get TAS version",
-        "description": "Returns the current version of the TEE Attestation Service",
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Version information",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VersionResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2,8 +2,7 @@ openapi: 3.0.2
 info:
   title: TEE Attestation Service API
   version: 0.1.0
-  description: A service for TEE (Trusted Execution Environment) attestation and key
-    management
+  description: A service for TEE (Trusted Execution Environment) attestation and key management
   contact:
     name: HPE Security Lab
     url: https://github.com/TEE-Attestation/tas
@@ -21,6 +20,11 @@ components:
       in: header
       name: X-API-KEY
       description: API key for authentication
+    ManagementApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-MANAGEMENT-API-KEY
+      description: Management API key for policy administration
   schemas:
     Error:
       type: object
@@ -178,6 +182,25 @@ components:
           example: 0.1.0
       required:
       - version
+  headers:
+    Deprecation:
+      description: Indicates the endpoint is deprecated (RFC 8594)
+      schema:
+        type: string
+        example: 'true'
+    Sunset:
+      description: Date after which the endpoint will be removed (RFC 8594, RFC 7231 IMF-fixdate)
+      schema:
+        type: string
+        example: Tue, 31 Mar 2026 23:59:59 GMT
+    Link:
+      description: Link to the replacement endpoint
+      schema:
+        type: string
+    Warning:
+      description: Human-readable deprecation warning
+      schema:
+        type: string
 paths:
   /kb/v0/get_nonce:
     get:
@@ -242,11 +265,256 @@ paths:
   /policy/v0/store:
     post:
       tags:
+      - Policy Management (Deprecated)
+      summary: Store a security policy
+      description: 'Stores a security policy for later use in attestation validation Deprecated: will be removed after 31
+        March 2026. Use /management/policy/v0/* endpoints instead.'
+      security:
+      - ManagementApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyStoreRequest'
+      responses:
+        '201':
+          description: Policy stored successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  warning:
+                    type: string
+                  deprecation_warning:
+                    type: string
+                    description: Deprecation notice for this endpoint
+          headers:
+            Deprecation: &id001
+              $ref: '#/components/headers/Deprecation'
+            Sunset: &id002
+              $ref: '#/components/headers/Sunset'
+            Link: &id003
+              $ref: '#/components/headers/Link'
+            Warning: &id004
+              $ref: '#/components/headers/Warning'
+        '400':
+          description: Bad request - Invalid policy data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            Deprecation: *id001
+            Sunset: *id002
+            Link: *id003
+            Warning: *id004
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            Deprecation: *id001
+            Sunset: *id002
+            Link: *id003
+            Warning: *id004
+      deprecated: true
+  /policy/v0/get/{policy_key}:
+    get:
+      tags:
+      - Policy Management (Deprecated)
+      summary: Get a security policy
+      description: 'Retrieves a stored security policy by key Deprecated: will be removed after 31 March 2026. Use /management/policy/v0/*
+        endpoints instead.'
+      security:
+      - ManagementApiKeyAuth: []
+      parameters:
+      - name: policy_key
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Policy key to retrieve
+      responses:
+        '200':
+          description: Policy retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  policy_key:
+                    type: string
+                  policy:
+                    $ref: '#/components/schemas/PolicyData'
+                  warning:
+                    type: string
+                  deprecation_warning:
+                    type: string
+                    description: Deprecation notice for this endpoint
+          headers:
+            Deprecation: *id001
+            Sunset: *id002
+            Link: *id003
+            Warning: *id004
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            Deprecation: *id001
+            Sunset: *id002
+            Link: *id003
+            Warning: *id004
+        '404':
+          description: Policy not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            Deprecation: *id001
+            Sunset: *id002
+            Link: *id003
+            Warning: *id004
+      deprecated: true
+  /policy/v0/list:
+    get:
+      tags:
+      - Policy Management (Deprecated)
+      summary: List all policies
+      description: 'Lists all stored security policies Deprecated: will be removed after 31 March 2026. Use /management/policy/v0/*
+        endpoints instead.'
+      security:
+      - ManagementApiKeyAuth: []
+      responses:
+        '200':
+          description: Policies listed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  policies:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        policy_key:
+                          type: string
+                        name:
+                          type: string
+                        version:
+                          type: string
+                        description:
+                          type: string
+                        signed:
+                          type: boolean
+                  count:
+                    type: integer
+                  deprecation_warning:
+                    type: string
+                    description: Deprecation notice for this endpoint
+          headers:
+            Deprecation: *id001
+            Sunset: *id002
+            Link: *id003
+            Warning: *id004
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            Deprecation: *id001
+            Sunset: *id002
+            Link: *id003
+            Warning: *id004
+      deprecated: true
+  /policy/v0/delete/{policy_name}:
+    delete:
+      tags:
+      - Policy Management (Deprecated)
+      summary: Delete a security policy
+      description: 'Deletes a stored security policy Deprecated: will be removed after 31 March 2026. Use /management/policy/v0/*
+        endpoints instead.'
+      security:
+      - ManagementApiKeyAuth: []
+      parameters:
+      - name: policy_name
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Policy name to delete
+      responses:
+        '200':
+          description: Policy deleted successfully
+          headers:
+            Deprecation: *id001
+            Sunset: *id002
+            Link: *id003
+            Warning: *id004
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            Deprecation: *id001
+            Sunset: *id002
+            Link: *id003
+            Warning: *id004
+        '404':
+          description: Policy not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            Deprecation: *id001
+            Sunset: *id002
+            Link: *id003
+            Warning: *id004
+      deprecated: true
+  /version:
+    get:
+      tags:
+      - System
+      summary: Get TAS version
+      description: Returns the current version of the TEE Attestation Service
+      security:
+      - ApiKeyAuth: []
+      responses:
+        '200':
+          description: Version information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VersionResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /management/policy/v0/store:
+    post:
+      tags:
       - Policy Management
       summary: Store a security policy
       description: Stores a security policy for later use in attestation validation
       security:
-      - ApiKeyAuth: []
+      - ManagementApiKeyAuth: []
       requestBody:
         required: true
         content:
@@ -272,19 +540,19 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '401':
-          description: Unauthorized
+          description: Unauthorized - Invalid management API key
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /policy/v0/get/{policy_key}:
+  /management/policy/v0/get/{policy_key}:
     get:
       tags:
       - Policy Management
       summary: Get a security policy
       description: Retrieves a stored security policy by key
       security:
-      - ApiKeyAuth: []
+      - ManagementApiKeyAuth: []
       parameters:
       - name: policy_key
         in: path
@@ -318,14 +586,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /policy/v0/list:
+  /management/policy/v0/list:
     get:
       tags:
       - Policy Management
       summary: List all policies
       description: Lists all stored security policies
       security:
-      - ApiKeyAuth: []
+      - ManagementApiKeyAuth: []
       responses:
         '200':
           description: Policies listed successfully
@@ -357,21 +625,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /policy/v0/delete/{policy_name}:
+  /management/policy/v0/delete/{policy_key}:
     delete:
       tags:
       - Policy Management
       summary: Delete a security policy
       description: Deletes a stored security policy
       security:
-      - ApiKeyAuth: []
+      - ManagementApiKeyAuth: []
       parameters:
-      - name: policy_name
+      - name: policy_key
         in: path
         required: true
         schema:
           type: string
-        description: Policy name to delete
+        description: Policy key to delete
       responses:
         '200':
           description: Policy deleted successfully
@@ -383,27 +651,6 @@ paths:
                 $ref: '#/components/schemas/Error'
         '404':
           description: Policy not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /version:
-    get:
-      tags:
-      - System
-      summary: Get TAS version
-      description: Returns the current version of the TEE Attestation Service
-      security:
-      - ApiKeyAuth: []
-      responses:
-        '200':
-          description: Version information
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VersionResponse'
-        '401':
-          description: Unauthorized
           content:
             application/json:
               schema:

--- a/tas/auth/__init__.py
+++ b/tas/auth/__init__.py
@@ -1,0 +1,21 @@
+#
+# TEE Attestation Service - Authentication Package
+#
+# Copyright 2026 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# This file is part of the TEE Attestation Service.
+#
+# This package provides authentication for TAS API routes,
+# split by role (client vs management) with pluggable mechanisms.
+#
+
+from .client_auth import authenticate_request, init_client_auth
+from .management_auth import authenticate_management_request, init_management_auth
+
+__all__ = [
+    "authenticate_request",
+    "authenticate_management_request",
+    "init_client_auth",
+    "init_management_auth",
+]

--- a/tas/auth/api_key.py
+++ b/tas/auth/api_key.py
@@ -1,0 +1,51 @@
+#
+# TEE Attestation Service - API Key Authenticator
+#
+# Copyright 2026 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# This file is part of the TEE Attestation Service.
+#
+# API key authentication mechanism using constant-time comparison.
+#
+
+import secrets
+
+from flask import current_app, jsonify
+
+from ..tas_logging import get_logger
+from .base import BaseAuthenticator
+
+logger = get_logger(__name__)
+
+
+class ApiKeyAuthenticator(BaseAuthenticator):
+    """Authenticate requests by comparing a header value to a configured key.
+
+    Uses secrets.compare_digest() for constant-time comparison to prevent
+    timing attacks.
+    """
+
+    def __init__(self, config_key, header_name):
+        """
+        Args:
+            config_key: Flask config key holding the expected API key
+                        (e.g. "TAS_API_KEY").
+            header_name: HTTP header to read the presented key from
+                         (e.g. "X-API-KEY").
+        """
+        self.config_key = config_key
+        self.header_name = header_name
+
+    def authenticate(self, request):
+        api_key = request.headers.get(self.header_name)
+        expected = current_app.config.get(self.config_key, "")
+
+        if not api_key or not secrets.compare_digest(str(api_key), str(expected)):
+            logger.warning(
+                f"Unauthorized request from {request.remote_addr}: "
+                f"Invalid or missing {self.header_name}"
+            )
+            return False, (jsonify({"error": "Unauthorized"}), 401)
+
+        return True, None

--- a/tas/auth/base.py
+++ b/tas/auth/base.py
@@ -1,0 +1,33 @@
+#
+# TEE Attestation Service - Base Authenticator
+#
+# Copyright 2026 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# This file is part of the TEE Attestation Service.
+#
+# Abstract base class for all authentication mechanisms.
+#
+
+from abc import ABC, abstractmethod
+
+
+class BaseAuthenticator(ABC):
+    """Abstract base for authentication mechanisms.
+
+    Subclasses implement a specific mechanism (API key, JWT, mTLS, etc.).
+    Each returns a tuple of (success: bool, error_response | None).
+    """
+
+    @abstractmethod
+    def authenticate(self, request):
+        """Authenticate an incoming request.
+
+        Args:
+            request: The Flask request object.
+
+        Returns:
+            (True, None) on success.
+            (False, (response, status_code)) on failure.
+        """
+        raise NotImplementedError

--- a/tas/auth/client_auth.py
+++ b/tas/auth/client_auth.py
@@ -1,0 +1,42 @@
+#
+# TEE Attestation Service - Client Authentication
+#
+# Copyright 2026 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# This file is part of the TEE Attestation Service.
+#
+# Authentication for client/attestation routes (/kb/v0/*, /version).
+#
+
+from flask import request
+
+from ..tas_logging import get_logger
+from .api_key import ApiKeyAuthenticator
+
+logger = get_logger(__name__)
+
+_authenticator = None
+
+
+def init_client_auth(app):
+    """Initialise the client authenticator from app config.
+
+    Called once during application startup.
+    """
+    global _authenticator
+    _authenticator = ApiKeyAuthenticator(
+        config_key="TAS_API_KEY",
+        header_name="X-API-KEY",
+    )
+    logger.info("Client authentication initialised (API key)")
+
+
+def authenticate_request():
+    """Authenticate an attestation/client API request.
+
+    Returns None on success, or a Flask error response tuple on failure.
+    """
+    ok, error = _authenticator.authenticate(request)
+    if not ok:
+        return error

--- a/tas/auth/management_auth.py
+++ b/tas/auth/management_auth.py
@@ -1,0 +1,42 @@
+#
+# TEE Attestation Service - Management Authentication
+#
+# Copyright 2026 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# This file is part of the TEE Attestation Service.
+#
+# Authentication for management routes (/management/policy/v0/*).
+#
+
+from flask import request
+
+from ..tas_logging import get_logger
+from .api_key import ApiKeyAuthenticator
+
+logger = get_logger(__name__)
+
+_authenticator = None
+
+
+def init_management_auth(app):
+    """Initialise the management authenticator from app config.
+
+    Called once during application startup.
+    """
+    global _authenticator
+    _authenticator = ApiKeyAuthenticator(
+        config_key="TAS_MANAGEMENT_API_KEY",
+        header_name="X-MANAGEMENT-API-KEY",
+    )
+    logger.info("Management authentication initialised (API key)")
+
+
+def authenticate_management_request():
+    """Authenticate a management API request.
+
+    Returns None on success, or a Flask error response tuple on failure.
+    """
+    ok, error = _authenticator.authenticate(request)
+    if not ok:
+        return error

--- a/tas/config.py
+++ b/tas/config.py
@@ -35,6 +35,10 @@ class BaseConfig:
     TAS_VERSION = "0.1.0"
     TAS_API_KEY = os.getenv("TAS_API_KEY", "")
     TAS_API_KEY_MIN_LENGTH = int(os.getenv("TAS_API_KEY_MIN_LENGTH", "64"))
+    TAS_MANAGEMENT_API_KEY = os.getenv("TAS_MANAGEMENT_API_KEY", "")
+    TAS_MANAGEMENT_API_KEY_MIN_LENGTH = int(
+        os.getenv("TAS_MANAGEMENT_API_KEY_MIN_LENGTH", "64")
+    )
     TAS_NONCE_EXPIRATION_SECONDS = int(os.getenv("TAS_NONCE_EXPIRATION_SECONDS", "120"))
     TAS_REDIS_HOST = os.getenv("TAS_REDIS_HOST", "localhost")
     TAS_REDIS_PORT = int(os.getenv("TAS_REDIS_PORT", "6379"))

--- a/tas/config_loader.py
+++ b/tas/config_loader.py
@@ -29,6 +29,8 @@ KNOWN_TAS_KEYS = {
     "TAS_VERSION",
     "TAS_API_KEY",
     "TAS_API_KEY_MIN_LENGTH",
+    "TAS_MANAGEMENT_API_KEY",
+    "TAS_MANAGEMENT_API_KEY_MIN_LENGTH",
     "TAS_NONCE_EXPIRATION_SECONDS",
     "TAS_REDIS_HOST",
     "TAS_REDIS_PORT",
@@ -302,6 +304,19 @@ def load_configuration(app):
         )
         raise RuntimeError(
             f"TAS_API_KEY must be at least {app.config['TAS_API_KEY_MIN_LENGTH']} characters long"
+        )
+
+    # Validate management API key
+    mgmt_api_key = app.config.get("TAS_MANAGEMENT_API_KEY", "")
+    if not mgmt_api_key:
+        logger.error("TAS_MANAGEMENT_API_KEY is not set")
+        raise RuntimeError("TAS_MANAGEMENT_API_KEY environment variable is not set")
+    if len(mgmt_api_key) < app.config["TAS_MANAGEMENT_API_KEY_MIN_LENGTH"]:
+        logger.error(
+            f"TAS_MANAGEMENT_API_KEY length {len(mgmt_api_key)} is less than required minimum {app.config['TAS_MANAGEMENT_API_KEY_MIN_LENGTH']}"
+        )
+        raise RuntimeError(
+            f"TAS_MANAGEMENT_API_KEY must be at least {app.config['TAS_MANAGEMENT_API_KEY_MIN_LENGTH']} characters long"
         )
 
     logger.debug("Loading trusted keys for policy verification")

--- a/tas/deprecated_routes.py
+++ b/tas/deprecated_routes.py
@@ -1,0 +1,122 @@
+#
+# TEE Attestation Service - Deprecated Policy Routes
+#
+# Copyright 2026 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# This file is part of the TEE Attestation Service.
+#
+# This module provides backward-compatible /policy/v0/* routes that
+# delegate to the canonical /management/policy/v0/* handlers while
+# emitting deprecation warnings and HTTP headers.
+#
+# These routes will be removed in a future release.
+#
+
+import json
+
+from flask import Blueprint, make_response, request
+
+from .management_routes import delete_policy, get_policy, list_policies, store_policy
+from .tas_logging import get_logger
+
+logger = get_logger(__name__)
+
+deprecated_policy_bp = Blueprint("deprecated_policy", __name__, url_prefix="/policy")
+
+# Target removal date for deprecated routes
+_SUNSET_DATE = "Tue, 31 Mar 2026 23:59:59 GMT"
+
+
+def _add_deprecation_headers(response, successor_path):
+    """Add standard deprecation headers to a response.
+
+    Headers follow RFC 8594 (Sunset) and the draft Deprecation header spec.
+    """
+    response.headers["Deprecation"] = "true"
+    response.headers["Sunset"] = _SUNSET_DATE
+    response.headers["Link"] = f'<{successor_path}>; rel="successor-version"'
+    response.headers["Warning"] = (
+        f'299 - "This endpoint is deprecated. Use {successor_path} instead. '
+        f'It will be removed after {_SUNSET_DATE}."'
+    )
+
+    # Inject deprecation_warning into JSON response body if applicable
+    if response.content_type and "application/json" in response.content_type:
+        try:
+            data = json.loads(response.get_data(as_text=True))
+            data["deprecation_warning"] = (
+                f"This endpoint is deprecated. Use {successor_path} instead. "
+                f"It will be removed after {_SUNSET_DATE}."
+            )
+            response.set_data(json.dumps(data))
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    return response
+
+
+@deprecated_policy_bp.route("/v0/store", methods=["POST"])
+def store_policy_deprecated():
+    logger.warning(
+        "DEPRECATED: /policy/v0/store called from %s. "
+        "Use /management/policy/v0/store instead.",
+        request.remote_addr,
+    )
+    result = store_policy()
+    if isinstance(result, tuple):
+        response = make_response(result[0], result[1])
+    else:
+        response = make_response(result)
+    return _add_deprecation_headers(response, "/management/policy/v0/store")
+
+
+@deprecated_policy_bp.route("/v0/get/<policy_key>", methods=["GET"])
+def get_policy_deprecated(policy_key):
+    logger.warning(
+        "DEPRECATED: /policy/v0/get/%s called from %s. "
+        "Use /management/policy/v0/get/%s instead.",
+        policy_key,
+        request.remote_addr,
+        policy_key,
+    )
+    result = get_policy(policy_key)
+    if isinstance(result, tuple):
+        response = make_response(result[0], result[1])
+    else:
+        response = make_response(result)
+    return _add_deprecation_headers(response, f"/management/policy/v0/get/{policy_key}")
+
+
+@deprecated_policy_bp.route("/v0/list", methods=["GET"])
+def list_policies_deprecated():
+    logger.warning(
+        "DEPRECATED: /policy/v0/list called from %s. "
+        "Use /management/policy/v0/list instead.",
+        request.remote_addr,
+    )
+    result = list_policies()
+    if isinstance(result, tuple):
+        response = make_response(result[0], result[1])
+    else:
+        response = make_response(result)
+    return _add_deprecation_headers(response, "/management/policy/v0/list")
+
+
+@deprecated_policy_bp.route("/v0/delete/<policy_key>", methods=["DELETE"])
+def delete_policy_deprecated(policy_key):
+    logger.warning(
+        "DEPRECATED: /policy/v0/delete/%s called from %s. "
+        "Use /management/policy/v0/delete/%s instead.",
+        policy_key,
+        request.remote_addr,
+        policy_key,
+    )
+    result = delete_policy(policy_key)
+    if isinstance(result, tuple):
+        response = make_response(result[0], result[1])
+    else:
+        response = make_response(result)
+    return _add_deprecation_headers(
+        response, f"/management/policy/v0/delete/{policy_key}"
+    )

--- a/tas/management_routes.py
+++ b/tas/management_routes.py
@@ -1,0 +1,264 @@
+#
+# TEE Attestation Service - Management Routes
+#
+# Copyright 2026 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# This file is part of the TEE Attestation Service.
+#
+# This module provides the management API blueprint for policy operations.
+# Canonical routes live under /management/policy/v0/*.
+#
+
+import json
+
+from flask import Blueprint, current_app, jsonify, request
+
+from .auth import authenticate_management_request
+from .policy_helper import (
+    POLICY_KEY_COMPONENT_RE,
+    validate_policy_key,
+    verify_policy_signature,
+)
+from .tas_logging import get_logger
+
+logger = get_logger(__name__)
+
+management_bp = Blueprint("management", __name__, url_prefix="/management")
+
+
+def _get_redis():
+    """Retrieve the Redis client from the application extensions."""
+    return current_app.extensions["redis"]
+
+
+@management_bp.route("/policy/v0/store", methods=["POST"])
+def store_policy():
+    """Store a security policy in Redis for later use in attestation validation."""
+    logger.info(f"Received policy store request from {request.remote_addr}")
+    auth_response = authenticate_management_request()
+    if auth_response:
+        return auth_response
+
+    data = request.get_json()
+    if not data:
+        logger.error("Policy store request missing JSON body")
+        return jsonify({"error": "Request body is required"}), 400
+
+    policy_type = data.get("policy_type")
+    if not policy_type:
+        logger.error("Policy store request missing policy_type")
+        return jsonify({"error": "Policy type is required (e.g. SEV, TDX)"}), 400
+
+    if not POLICY_KEY_COMPONENT_RE.match(str(policy_type)):
+        logger.error(f"Invalid policy_type: {policy_type}")
+        return (
+            jsonify(
+                {
+                    "error": "Invalid policy_type. Use only alphanumeric characters, hyphens, underscores, and dots"
+                }
+            ),
+            400,
+        )
+
+    key_id = data.get("key_id")
+    if not key_id:
+        logger.error("Policy store request missing key_id")
+        return jsonify({"error": "Key ID is required"}), 400
+
+    if not POLICY_KEY_COMPONENT_RE.match(str(key_id)):
+        logger.error(f"Invalid key_id: {key_id}")
+        return (
+            jsonify(
+                {
+                    "error": "Invalid key_id. Use only alphanumeric characters, hyphens, underscores, and dots"
+                }
+            ),
+            400,
+        )
+
+    policy = data.get("policy")
+    if not policy:
+        logger.error("Policy store request missing policy data")
+        return jsonify({"error": "Policy data is required"}), 400
+
+    if not isinstance(policy, dict):
+        logger.error("Policy data is not a valid JSON object")
+        return jsonify({"error": "Policy must be a JSON object"}), 400
+
+    if "metadata" not in policy:
+        logger.error("Policy missing required 'metadata' section")
+        return jsonify({"error": "Policy must contain 'metadata' section"}), 400
+
+    if "validation_rules" not in policy:
+        logger.error("Policy missing required 'validation_rules' section")
+        return jsonify({"error": "Policy must contain 'validation_rules' section"}), 400
+
+    is_signed = "signature" in policy
+    warning_message = None
+    if not is_signed:
+        logger.warning(f"Policy {policy_type}:{key_id} is not signed")
+        warning_message = (
+            "WARNING: Policy is not signed and cannot be verified for integrity"
+        )
+        if current_app.config.get("TAS_ENFORCE_SIGNED_POLICIES", True):
+            logger.error("Unsigned policies are not allowed by configuration")
+            return (
+                jsonify(
+                    {"error": "Unsigned policies are not allowed by configuration"}
+                ),
+                400,
+            )
+    else:
+        logger.info(f"Policy {policy_type}:{key_id} is signed")
+        if not current_app.config.get("TAS_ENFORCE_SIGNED_POLICIES", True):
+            logger.warning(
+                "Signed policy not verified - policy signature check is disabled"
+            )
+            warning_message = "WARNING: Signed policy not verified - policy signature check is disabled"
+        else:
+            if not verify_policy_signature(
+                policy, current_app.config.get("TAS_TRUSTED_KEYS", [])
+            ):
+                logger.error("Policy signature verification failed")
+                return jsonify({"error": "Policy signature verification failed"}), 400
+            logger.info("Policy signature verification successful")
+
+    try:
+        redis_client = _get_redis()
+        policy_key = f"policy:{policy_type}:{key_id}"
+        policy_json = json.dumps(policy)
+
+        redis_client.set(policy_key, policy_json)
+
+        logger.info(f"Stored policy '{policy_key}' in Redis")
+
+        response_data = {"message": f"Policy '{policy_key}' stored successfully"}
+        if warning_message:
+            response_data["warning"] = warning_message
+
+        return jsonify(response_data), 201
+
+    except Exception as e:
+        logger.error(f"Error storing policy: {e}")
+        return jsonify({"error": "Failed to store policy in Redis"}), 500
+
+
+@management_bp.route("/policy/v0/get/<policy_key>", methods=["GET"])
+def get_policy(policy_key):
+    """Retrieve a security policy from Redis."""
+    logger.info(
+        f"Received policy get request for '{policy_key}' from {request.remote_addr}"
+    )
+    auth_response = authenticate_management_request()
+    if auth_response:
+        return auth_response
+
+    is_valid, error_message = validate_policy_key(policy_key)
+    if not is_valid:
+        logger.error(f"Invalid policy key '{policy_key}': {error_message}")
+        return jsonify({"error": error_message}), 400
+
+    try:
+        redis_client = _get_redis()
+        logger.debug(f"Retrieving policy '{policy_key}' from Redis")
+        policy_json = redis_client.get(policy_key)
+
+        if not policy_json:
+            logger.warning(f"Policy '{policy_key}' not found in Redis")
+            return jsonify({"error": f"Policy '{policy_key}' not found"}), 404
+
+        policy = json.loads(policy_json)
+        logger.info(f"Successfully retrieved policy '{policy_key}'")
+
+        response_data = {"policy_key": policy_key, "policy": policy}
+        if "signature" not in policy:
+            logger.warning(f"Retrieved policy '{policy_key}' is not signed")
+            response_data[
+                "warning"
+            ] = "WARNING: Policy is not signed and cannot be verified for integrity"
+
+        return jsonify(response_data), 200
+
+    except json.JSONDecodeError as e:
+        logger.error(f"Error parsing policy JSON: {e}")
+        return jsonify({"error": "Invalid policy data in Redis"}), 500
+    except Exception as e:
+        logger.error(f"Error retrieving policy: {e}")
+        return jsonify({"error": "Failed to retrieve policy from Redis"}), 500
+
+
+@management_bp.route("/policy/v0/list", methods=["GET"])
+def list_policies():
+    """List all stored policies in Redis."""
+    logger.info(f"Received policy list request from {request.remote_addr}")
+    auth_response = authenticate_management_request()
+    if auth_response:
+        return auth_response
+
+    try:
+        redis_client = _get_redis()
+        logger.debug("Retrieving all policy keys from Redis")
+        policy_keys = redis_client.keys("policy:*")
+        logger.debug(f"Found {len(policy_keys)} policy keys in Redis")
+
+        policies = []
+        for key in policy_keys:
+            policy_json = redis_client.get(key)
+
+            if policy_json:
+                try:
+                    policy = json.loads(policy_json)
+                    metadata = policy.get("metadata", {})
+                    policy_info = {
+                        "policy_key": key,
+                        "name": metadata.get("name", "Unknown"),
+                        "version": metadata.get("version", "Unknown"),
+                        "description": metadata.get("description", "No description"),
+                        "signed": "signature" in policy,
+                    }
+                    policies.append(policy_info)
+                    logger.debug(f"Added policy to list: {key}")
+                except json.JSONDecodeError:
+                    logger.warning(f"Skipping invalid policy with key: {key}")
+                    continue
+
+        logger.info(f"Successfully listed {len(policies)} policies")
+        return jsonify({"policies": policies, "count": len(policies)}), 200
+
+    except Exception as e:
+        logger.error(f"Error listing policies: {e}")
+        return jsonify({"error": "Failed to list policies"}), 500
+
+
+@management_bp.route("/policy/v0/delete/<policy_key>", methods=["DELETE"])
+def delete_policy(policy_key):
+    """Delete a security policy from Redis."""
+    logger.info(
+        f"Received policy delete request for '{policy_key}' from {request.remote_addr}"
+    )
+    auth_response = authenticate_management_request()
+    if auth_response:
+        return auth_response
+
+    is_valid, error_message = validate_policy_key(policy_key)
+    if not is_valid:
+        logger.error(f"Invalid policy key '{policy_key}': {error_message}")
+        return jsonify({"error": error_message}), 400
+
+    try:
+        redis_client = _get_redis()
+        logger.debug(f"Attempting to delete policy with key: {policy_key}")
+        deleted_count = redis_client.delete(policy_key)
+
+        if deleted_count == 0:
+            logger.warning(f"Policy '{policy_key}' not found for deletion")
+            return jsonify({"error": f"Policy '{policy_key}' not found"}), 404
+
+        logger.info(f"Deleted policy '{policy_key}' from Redis")
+
+        return jsonify({"message": f"Policy '{policy_key}' deleted successfully"}), 200
+
+    except Exception as e:
+        logger.error(f"Error deleting policy: {e}")
+        return jsonify({"error": "Failed to delete policy from Redis"}), 500

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -20,6 +20,7 @@ from flask import Flask
 from tas.config_loader import load_configuration
 
 LONG_API_KEY = "a" * 64
+LONG_MGMT_KEY = "b" * 64
 
 
 def new_app():
@@ -57,6 +58,7 @@ def test_api_key_min_length(monkeypatch):
 
 def test_flask_env_overrides(monkeypatch):
     monkeypatch.setenv("TAS_API_KEY", LONG_API_KEY)
+    monkeypatch.setenv("TAS_MANAGEMENT_API_KEY", LONG_MGMT_KEY)
     monkeypatch.setenv("FLASK_DEBUG", "true")
     monkeypatch.setenv("FLASK_JSON_SORT_KEYS", "false")
     app = new_app()
@@ -67,6 +69,7 @@ def test_flask_env_overrides(monkeypatch):
 
 def test_tas_direct_env_overrides(monkeypatch):
     monkeypatch.setenv("TAS_API_KEY", LONG_API_KEY)
+    monkeypatch.setenv("TAS_MANAGEMENT_API_KEY", LONG_MGMT_KEY)
     monkeypatch.setenv("TAS_REDIS_HOST", "redis.internal")
     monkeypatch.setenv("TAS_REDIS_PORT", "6380")
     app = new_app()
@@ -90,6 +93,7 @@ def test_structured_file_uppercase_only(tmp_path, monkeypatch):
 
     monkeypatch.setenv("TAS_CONFIG_FILE", str(cfg))
     monkeypatch.setenv("TAS_API_KEY", LONG_API_KEY)
+    monkeypatch.setenv("TAS_MANAGEMENT_API_KEY", LONG_MGMT_KEY)
 
     app = new_app()
     load_configuration(app)
@@ -122,6 +126,7 @@ def test_structured_file_TAS_bucket_deep_merge(tmp_path, monkeypatch):
 
     monkeypatch.setenv("TAS_CONFIG_FILE", str(cfg))
     monkeypatch.setenv("TAS_API_KEY", LONG_API_KEY)
+    monkeypatch.setenv("TAS_MANAGEMENT_API_KEY", LONG_MGMT_KEY)
     # Add an env override that should merge/override nested value
     monkeypatch.setenv("TAS_OVERRIDE__limits__max_nonce_per_minute", "250")
 
@@ -141,6 +146,7 @@ def test_env_precedence_over_file(tmp_path, monkeypatch):
 
     monkeypatch.setenv("TAS_CONFIG_FILE", str(cfg))
     monkeypatch.setenv("TAS_API_KEY", LONG_API_KEY)
+    monkeypatch.setenv("TAS_MANAGEMENT_API_KEY", LONG_MGMT_KEY)
     monkeypatch.setenv("TAS_REDIS_HOST", "from_env")
 
     app = new_app()
@@ -153,7 +159,25 @@ def test_env_precedence_over_file(tmp_path, monkeypatch):
 def test_tas_override_nested_lowercasing(monkeypatch):
     # Loader lowercases TAS_OVERRIDE__ path parts
     monkeypatch.setenv("TAS_API_KEY", LONG_API_KEY)
+    monkeypatch.setenv("TAS_MANAGEMENT_API_KEY", LONG_MGMT_KEY)
     monkeypatch.setenv("TAS_OVERRIDE__Auth__JWKS__cache_seconds", "300")
     app = new_app()
     load_configuration(app)
     assert app.config["TAS"]["auth"]["jwks"]["cache_seconds"] == 300
+
+
+def test_requires_management_api_key(monkeypatch):
+    monkeypatch.setenv("TAS_API_KEY", LONG_API_KEY)
+    app = new_app()
+    with pytest.raises(
+        RuntimeError, match="TAS_MANAGEMENT_API_KEY environment variable is not set"
+    ):
+        load_configuration(app)
+
+
+def test_management_api_key_min_length(monkeypatch):
+    monkeypatch.setenv("TAS_API_KEY", LONG_API_KEY)
+    monkeypatch.setenv("TAS_MANAGEMENT_API_KEY", "short")
+    app = new_app()
+    with pytest.raises(RuntimeError, match="TAS_MANAGEMENT_API_KEY must be at least"):
+        load_configuration(app)

--- a/tests/test_management_routes.py
+++ b/tests/test_management_routes.py
@@ -1,0 +1,313 @@
+#
+# TEE Attestation Service - Tests for Management Routes & Deprecation
+#
+# Copyright 2026 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# This file is part of the TEE Attestation Service.
+#
+
+import json
+import os
+
+import pytest
+from flask import Flask
+
+from tas.auth import init_client_auth, init_management_auth
+from tas.deprecated_routes import deprecated_policy_bp
+from tas.management_routes import management_bp
+
+CLIENT_API_KEY = "a" * 64
+MGMT_API_KEY = "b" * 64
+
+VALID_POLICY_PAYLOAD = {
+    "policy_type": "SEV",
+    "key_id": "test-key-1",
+    "policy": {
+        "metadata": {
+            "name": "Test Policy",
+            "version": "1.0",
+            "description": "A test policy",
+        },
+        "validation_rules": {
+            "host_data": {"exact_match": "abc123"},
+            "policy": {"debug_allowed": False},
+        },
+    },
+}
+
+
+class FakeRedis:
+    """Minimal in-memory Redis stub for testing."""
+
+    def __init__(self):
+        self._store = {}
+
+    def set(self, key, value):
+        self._store[key] = value
+
+    def get(self, key):
+        return self._store.get(key)
+
+    def delete(self, key):
+        if key in self._store:
+            del self._store[key]
+            return 1
+        return 0
+
+    def keys(self, pattern="*"):
+        import fnmatch
+
+        return [k for k in self._store if fnmatch.fnmatch(k, pattern)]
+
+    def setex(self, key, ttl, value):
+        self._store[key] = value
+
+
+@pytest.fixture()
+def app():
+    """Create a test Flask app with both blueprints registered."""
+    test_app = Flask(__name__)
+    test_app.config["TESTING"] = True
+    test_app.config["TAS_API_KEY"] = CLIENT_API_KEY
+    test_app.config["TAS_MANAGEMENT_API_KEY"] = MGMT_API_KEY
+    test_app.config["TAS_ENFORCE_SIGNED_POLICIES"] = False
+
+    fake_redis = FakeRedis()
+    test_app.extensions["redis"] = fake_redis
+
+    init_client_auth(test_app)
+    init_management_auth(test_app)
+
+    test_app.register_blueprint(management_bp)
+    test_app.register_blueprint(deprecated_policy_bp)
+
+    return test_app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def mgmt_headers():
+    return {"X-MANAGEMENT-API-KEY": MGMT_API_KEY, "Content-Type": "application/json"}
+
+
+@pytest.fixture()
+def client_headers():
+    return {"X-API-KEY": CLIENT_API_KEY, "Content-Type": "application/json"}
+
+
+# -- Management route tests --
+
+
+class TestManagementStorePolicy:
+    def test_store_policy_success(self, client, mgmt_headers):
+        resp = client.post(
+            "/management/policy/v0/store",
+            headers=mgmt_headers,
+            data=json.dumps(VALID_POLICY_PAYLOAD),
+        )
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert "stored successfully" in data["message"]
+
+    def test_store_policy_wrong_key_rejected(self, client, client_headers):
+        """Using the client API key (X-API-KEY) should be rejected."""
+        resp = client.post(
+            "/management/policy/v0/store",
+            headers=client_headers,
+            data=json.dumps(VALID_POLICY_PAYLOAD),
+        )
+        assert resp.status_code == 401
+
+    def test_store_policy_no_key_rejected(self, client):
+        resp = client.post(
+            "/management/policy/v0/store",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps(VALID_POLICY_PAYLOAD),
+        )
+        assert resp.status_code == 401
+
+    def test_store_policy_missing_body(self, client, mgmt_headers):
+        resp = client.post("/management/policy/v0/store", headers=mgmt_headers)
+        assert resp.status_code == 400
+
+    def test_store_policy_missing_policy_type(self, client, mgmt_headers):
+        payload = {**VALID_POLICY_PAYLOAD, "policy_type": None}
+        resp = client.post(
+            "/management/policy/v0/store",
+            headers=mgmt_headers,
+            data=json.dumps(payload),
+        )
+        assert resp.status_code == 400
+
+    def test_store_policy_invalid_policy_type(self, client, mgmt_headers):
+        payload = {**VALID_POLICY_PAYLOAD, "policy_type": "bad chars!@#"}
+        resp = client.post(
+            "/management/policy/v0/store",
+            headers=mgmt_headers,
+            data=json.dumps(payload),
+        )
+        assert resp.status_code == 400
+
+
+class TestManagementGetPolicy:
+    def test_get_policy_success(self, client, mgmt_headers, app):
+        # Store a policy first
+        app.extensions["redis"].set(
+            "policy:SEV:test-key-1",
+            json.dumps(VALID_POLICY_PAYLOAD["policy"]),
+        )
+        resp = client.get(
+            "/management/policy/v0/get/policy:SEV:test-key-1",
+            headers=mgmt_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["policy_key"] == "policy:SEV:test-key-1"
+
+    def test_get_policy_not_found(self, client, mgmt_headers):
+        resp = client.get(
+            "/management/policy/v0/get/policy:SEV:nonexistent",
+            headers=mgmt_headers,
+        )
+        assert resp.status_code == 404
+
+    def test_get_policy_invalid_key_format(self, client, mgmt_headers):
+        resp = client.get(
+            "/management/policy/v0/get/bad-key-format",
+            headers=mgmt_headers,
+        )
+        assert resp.status_code == 400
+
+
+class TestManagementListPolicies:
+    def test_list_policies_empty(self, client, mgmt_headers):
+        resp = client.get("/management/policy/v0/list", headers=mgmt_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["count"] == 0
+        assert data["policies"] == []
+
+    def test_list_policies_with_data(self, client, mgmt_headers, app):
+        app.extensions["redis"].set(
+            "policy:SEV:key1",
+            json.dumps(VALID_POLICY_PAYLOAD["policy"]),
+        )
+        resp = client.get("/management/policy/v0/list", headers=mgmt_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["count"] == 1
+
+
+class TestManagementDeletePolicy:
+    def test_delete_policy_success(self, client, mgmt_headers, app):
+        app.extensions["redis"].set(
+            "policy:SEV:to-delete",
+            json.dumps(VALID_POLICY_PAYLOAD["policy"]),
+        )
+        resp = client.delete(
+            "/management/policy/v0/delete/policy:SEV:to-delete",
+            headers=mgmt_headers,
+        )
+        assert resp.status_code == 200
+        assert "deleted successfully" in resp.get_json()["message"]
+
+    def test_delete_policy_not_found(self, client, mgmt_headers):
+        resp = client.delete(
+            "/management/policy/v0/delete/policy:SEV:nonexistent",
+            headers=mgmt_headers,
+        )
+        assert resp.status_code == 404
+
+
+# -- Deprecated route tests --
+
+
+class TestDeprecatedRoutes:
+    """Verify old /policy/v0/* routes still work but emit deprecation headers."""
+
+    def test_deprecated_store_works(self, client, mgmt_headers):
+        resp = client.post(
+            "/policy/v0/store",
+            headers=mgmt_headers,
+            data=json.dumps(VALID_POLICY_PAYLOAD),
+        )
+        assert resp.status_code == 201
+
+    def test_deprecated_store_has_deprecation_header(self, client, mgmt_headers):
+        resp = client.post(
+            "/policy/v0/store",
+            headers=mgmt_headers,
+            data=json.dumps(VALID_POLICY_PAYLOAD),
+        )
+        assert resp.headers.get("Deprecation") == "true"
+        assert resp.headers.get("Sunset") is not None
+        assert "successor-version" in resp.headers.get("Link", "")
+
+    def test_deprecated_store_body_has_warning(self, client, mgmt_headers):
+        resp = client.post(
+            "/policy/v0/store",
+            headers=mgmt_headers,
+            data=json.dumps(VALID_POLICY_PAYLOAD),
+        )
+        data = resp.get_json()
+        assert "deprecation_warning" in data
+
+    def test_deprecated_list_has_deprecation_header(self, client, mgmt_headers):
+        resp = client.get("/policy/v0/list", headers=mgmt_headers)
+        assert resp.status_code == 200
+        assert resp.headers.get("Deprecation") == "true"
+
+    def test_deprecated_get_has_deprecation_header(self, client, mgmt_headers, app):
+        app.extensions["redis"].set(
+            "policy:SEV:dep-test",
+            json.dumps(VALID_POLICY_PAYLOAD["policy"]),
+        )
+        resp = client.get(
+            "/policy/v0/get/policy:SEV:dep-test",
+            headers=mgmt_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.headers.get("Deprecation") == "true"
+        data = resp.get_json()
+        assert "deprecation_warning" in data
+
+    def test_deprecated_delete_has_deprecation_header(self, client, mgmt_headers, app):
+        app.extensions["redis"].set(
+            "policy:SEV:dep-del",
+            json.dumps(VALID_POLICY_PAYLOAD["policy"]),
+        )
+        resp = client.delete(
+            "/policy/v0/delete/policy:SEV:dep-del",
+            headers=mgmt_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.headers.get("Deprecation") == "true"
+
+    def test_deprecated_routes_use_management_key(self, client, client_headers):
+        """Old routes should require X-MANAGEMENT-API-KEY, not X-API-KEY."""
+        resp = client.get("/policy/v0/list", headers=client_headers)
+        assert resp.status_code == 401
+
+    def test_deprecated_routes_no_key_rejected(self, client):
+        resp = client.get("/policy/v0/list")
+        assert resp.status_code == 401
+
+
+# -- Key separation tests --
+
+
+class TestKeySeparation:
+    """Verify that client and management keys are not interchangeable."""
+
+    def test_management_route_rejects_client_key(self, client, client_headers):
+        resp = client.get("/management/policy/v0/list", headers=client_headers)
+        assert resp.status_code == 401
+
+    def test_management_route_accepts_mgmt_key(self, client, mgmt_headers):
+        resp = client.get("/management/policy/v0/list", headers=mgmt_headers)
+        assert resp.status_code == 200


### PR DESCRIPTION
Move policy CRUD endpoints to /management/policy/v0/* with a dedicated X-MANAGEMENT-API-KEY header, separating them from client attestation endpoints that use X-API-KEY.

- Extract auth logic into tas/auth/ module
- Move policy routes from app.py into management_routes blueprint
- Add deprecated_routes blueprint to keep old /policy/v0/* endpoints with RFC 8594 deprecation headers (sunset: 31 March 2026)
- Add TAS_MANAGEMENT_API_KEY and TAS_MANAGEMENT_API_KEY_MIN_LENGTH config
- Update README, CONFIG.md, POLICY.md, and OpenAPI specs
- Add management route tests