### PR TITLE
Add report-data binding and GPU attestation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,6 @@ tas.log
 
 # Nekos/act config files
 .actrc
+
+#VS Code settings
+.vscode/

--- a/app.py
+++ b/app.py
@@ -296,15 +296,17 @@ def get_secret():
     logger.debug(f"Received TEE evidence: {tee_evidence}")
     logger.debug(f"Received Key ID: {key_id}")
 
-    # Call vm_verify to validate the parameters
-    logger.info(f"Starting TEE verification for type: {tee_type}")
-    is_verified, verify_error = vm_verify(
-        redis_client, nonce, tee_type, tee_evidence, key_id
-    )
-    if not is_verified:
-        logger.error(f"TEE verification failed: {verify_error}")
-        return jsonify({"error": "TEE verification failed"}), 400
-    logger.info("TEE verification successful")
+    # Report data binding is required for this route,
+    # create a new route for non-binding use cases if needed in the future
+    report_data_binding = data.get("report-data-binding")
+    if report_data_binding is None:
+        logger.error("Secret request missing report data binding")
+        return jsonify({"error": "Report data binding is required"}), 400
+
+    logger.debug(f"Received report data binding: {report_data_binding}")
+
+    # Optional GPU evidence for Phase 2 - if provided, it will be passed to the vm_verify function
+    gpu_evidence = data.get("gpu-evidence", None)  # Phase 2
 
     # Get client's wrapping key (RSA public key) from the request
     # The public key is expected to be in base64 format
@@ -328,6 +330,22 @@ def get_secret():
     if not isinstance(wrapping_key, bytes):
         logger.error("Invalid wrapping key format: not bytes")
         return jsonify({"error": "Invalid wrapping key format"}), 400
+
+    # Call vm_verify to validate the parameters
+    logger.info(f"Starting TEE verification for type: {tee_type}")
+    is_verified, verify_error = vm_verify(
+        redis_client,
+        nonce,
+        tee_type,
+        tee_evidence,
+        key_id,
+        wrapping_key=wrapping_key,
+        report_data_binding=report_data_binding,
+        gpu_evidence=gpu_evidence,  # NEW (for Phase 2)
+    )
+    if not is_verified:
+        logger.error(f"TEE verification failed: {verify_error}")
+        return jsonify({"error": "TEE verification failed"}), 400
 
     # Retrieve the secret from the KMIP Broker Module
     logger.info(f"Retrieving secret for key ID: {key_id}")

--- a/tas/tas_vm.py
+++ b/tas/tas_vm.py
@@ -10,6 +10,7 @@
 #
 
 import base64
+import hashlib
 import json
 import os
 from urllib.parse import unquote
@@ -462,15 +463,24 @@ def get_policy_from_redis(redis_client: redis.StrictRedis, policy_key: str):
     return policy_json
 
 
-def sev_vm_verify(redis_client: redis.StrictRedis, nonce, decoded_evidence, key_id):
+def sev_vm_verify(
+    redis_client: redis.StrictRedis,
+    nonce,
+    decoded_evidence,
+    key_id,
+    expected_report_data=None,
+):
     """
     Verifies the decoded evidence for AMD SEV-SNP.
 
     Parameters:
-        redis_client: The Redis client instance.
+        redis_client (redis.StrictRedis): Redis client instance for database operations.
         nonce (str): The nonce to verify.
         decoded_evidence (bytes): The decoded TEE evidence.
         key_id (str): The key identifier.
+        expected_report_data (bytes, optional): Pre-computed expected report data.
+            When provided, used directly for verification instead of encoding
+            the nonce. Typically a SHA-512 digest from vm_verify's binding logic.
 
     Returns:
         bool: True if verification is successful, False otherwise.
@@ -525,6 +535,12 @@ def sev_vm_verify(redis_client: redis.StrictRedis, nonce, decoded_evidence, key_
         logger.error(f"Policy validation failed: {e}")
         return False, str(e)
 
+    # Use provided report_data or fall back to nonce
+    if expected_report_data is not None:
+        report_data = expected_report_data
+    else:
+        report_data = nonce.encode("utf-8")
+
     # Verify the TEE evidence
     try:
         policy = sev.AttestationPolicy(policy_json)
@@ -534,7 +550,7 @@ def sev_vm_verify(redis_client: redis.StrictRedis, nonce, decoded_evidence, key_
             certificates=certs,
             crl=crl,
             policy=policy,
-            report_data=nonce.encode("utf-8"),
+            report_data=report_data,
         )
         logger.debug("Completed sev_pytools attestation verification")
 
@@ -553,15 +569,24 @@ def sev_vm_verify(redis_client: redis.StrictRedis, nonce, decoded_evidence, key_
         return False, f"Verification error: {str(e)}"
 
 
-def tdx_vm_verify(redis_client: redis.StrictRedis, nonce, decoded_evidence, key_id):
+def tdx_vm_verify(
+    redis_client: redis.StrictRedis,
+    nonce,
+    decoded_evidence,
+    key_id,
+    expected_report_data=None,
+):
     """
     Verifies the decoded evidence for Intel TDX.
 
     Parameters:
-        redis_client: The Redis client instance.
+        redis_client (redis.StrictRedis): Redis client instance for database operations.
         nonce (str): The nonce to verify.
         decoded_evidence (bytes): The decoded TEE evidence.
         key_id (str): The key identifier.
+        expected_report_data (bytes, optional): Pre-computed expected report data.
+            When provided, used directly for verification instead of encoding
+            the nonce. Typically a SHA-512 digest from vm_verify's binding logic.
 
     Returns:
         bool: True if verification is successful, False otherwise.
@@ -631,8 +656,14 @@ def tdx_vm_verify(redis_client: redis.StrictRedis, nonce, decoded_evidence, key_
     )
     logger.info(f"TDX combined status: {combined_status}")
 
+    # Use provided report_data or fall back to nonce
+    if expected_report_data is not None:
+        report_data = expected_report_data
+    else:
+        report_data = nonce.encode("utf-8")
+
     try:
-        verified = policy.validate_quote(quote, tcb_dict, nonce.encode("utf-8"))
+        verified = policy.validate_quote(quote, tcb_dict, report_data)
         logger.info("Policy validation successful for TDX quote")
         log_function_exit("tdx_vm_verify", "success")
         return verified, None
@@ -643,15 +674,74 @@ def tdx_vm_verify(redis_client: redis.StrictRedis, nonce, decoded_evidence, key_
     return False, None
 
 
-def vm_verify(redis_client, nonce, tee_type, tee_evidence, key_id):
+def gpu_vm_verify(gpu_tee_type, gpu_evidence_b64, device_index):
     """
-    Verifies the provided nonce, TEE type, and TEE evidence.
+    Verify a single GPU's attestation evidence (stub).
 
     Parameters:
+        gpu_tee_type (str): The type of GPU TEE (e.g., "nvidia-hopper").
+        gpu_evidence_b64 (str): Base64-encoded GPU attestation evidence.
+        device_index (int): The index of the GPU device being verified.
+
+    Returns:
+        bool: True if verification is successful, False otherwise.
+        str: An error message if verification fails, None otherwise.
+    """
+    log_function_entry("gpu_vm_verify")
+    try:
+        gpu_raw = base64.b64decode(gpu_evidence_b64)
+        if len(gpu_raw) == 0:
+            return False, f"GPU {device_index}: empty evidence"
+
+        # TODO: dispatch to GPU-specific verification based on gpu_tee_type
+        logger.warning(
+            f"GPU {device_index} ({gpu_tee_type}): "
+            "verification not yet implemented, accepting on structure only"
+        )
+        log_function_exit("gpu_vm_verify", "stub-accepted")
+        return (
+            False,
+            f"GPU {device_index} ({gpu_tee_type}): verification not yet implemented",
+        )
+    except Exception as e:
+        log_function_exit("gpu_vm_verify", "error")
+        return False, f"GPU {device_index} verification error: {e}"
+
+
+def vm_verify(
+    redis_client,
+    nonce,
+    tee_type,
+    tee_evidence,
+    key_id,
+    wrapping_key=None,
+    report_data_binding=False,
+    gpu_evidence=None,
+):
+    """
+    Verifies the provided nonce, TEE type, and TEE evidence, with optional
+    wrapping key binding and GPU attestation.
+
+    Parameters:
+        redis_client (redis.StrictRedis): Redis client instance for database operations.
         nonce (str): The nonce to verify.
         tee_type (str): The type of TEE (e.g., "amd-sev-snp", "intel-tdx").
         tee_evidence (str): Base64-encoded TEE evidence.
         key_id (str): The key identifier.
+        wrapping_key (bytes, optional): The wrapping key for report data binding.
+        report_data_binding (bool, optional): When True (and wrapping_key is provided),
+            the expected report_data is computed as SHA-512(nonce || wrapping_key
+            [|| SHA-512(gpu0_evidence) || SHA-512(gpu1_evidence) || ...])
+            instead of using the raw nonce. Must be provided
+            in the request; cannot be None.
+        gpu_evidence (list, optional): List of per-GPU attestation evidence dicts,
+            each containing:
+                - "tee-type"      (str): GPU TEE type (e.g., "nvidia-hopper").
+                - "tee-evidence"  (str): Base64-encoded GPU attestation evidence.
+                - "device-index"  (int): GPU device index (used for ordering).
+            When present and report_data_binding is True, each GPU is verified
+            independently via gpu_vm_verify and its SHA-512 evidence hash is
+            appended to the report_data binding computation.
 
     Returns:
         bool: True if verification is successful, False otherwise.
@@ -659,7 +749,6 @@ def vm_verify(redis_client, nonce, tee_type, tee_evidence, key_id):
     """
     log_function_entry("vm_verify", nonce="***", tee_type=tee_type)
 
-    # Example verification logic (replace with actual verification logic)
     if not nonce:
         logger.error("Nonce is invalid")
         return False, "Nonce is invalid"
@@ -669,24 +758,68 @@ def vm_verify(redis_client, nonce, tee_type, tee_evidence, key_id):
         return False, "TEE type is invalid"
 
     try:
-        # Decode the base64-encoded TEE evidence
         decoded_evidence = base64.b64decode(tee_evidence)
     except Exception as e:
         logger.error(f"Failed to decode TEE evidence: {e}")
         return False, "TEE evidence is invalid"
 
-    # Check if the decoded evidence is non-empty
     if not decoded_evidence:
         logger.error("Decoded TEE evidence is empty")
         return False, "Decoded TEE evidence is empty"
 
+    # --- Compute expected report_data ---
+    if report_data_binding and wrapping_key:
+        # Recompute the same SHA-512 binding the agent used
+        hash_input = nonce.encode("utf-8") + wrapping_key
+
+        # Phase 2: include per-GPU evidence hashes
+        if gpu_evidence:
+            if len(gpu_evidence) > 16:
+                logger.error(f"Too many GPU evidence entries: {len(gpu_evidence)}")
+                return False, "Too many GPU evidence entries (max 16)"
+
+            gpu_evidence_sorted = sorted(gpu_evidence, key=lambda e: e["device-index"])
+
+            # Verify each GPU and build hash chain in a single pass
+            gpu_hashes = []
+            for gpu_entry in gpu_evidence_sorted:
+                gpu_ok, gpu_err = gpu_vm_verify(
+                    gpu_entry.get("tee-type", "unknown"),
+                    gpu_entry.get("tee-evidence", ""),
+                    gpu_entry.get("device-index", -1),
+                )
+                if not gpu_ok:
+                    return False, gpu_err
+
+                gpu_raw = base64.b64decode(gpu_entry["tee-evidence"])
+                gpu_hashes.append(hashlib.sha512(gpu_raw).digest())
+
+            # Append SHA-512 hashes: SHA512(gpu0_raw) || SHA512(gpu1_raw) || ...
+            for h in gpu_hashes:
+                hash_input += h
+
+        expected_report_data = hashlib.sha512(hash_input).digest()  # 64 bytes
+    else:
+        expected_report_data = nonce.encode("utf-8")
+
     logger.info(f"Verifying evidence for TEE type: {tee_type}")
 
-    # Call the appropriate verification function based on tee_type
     if tee_type == "amd-sev-snp":
-        result = sev_vm_verify(redis_client, nonce, decoded_evidence, key_id)
+        result = sev_vm_verify(
+            redis_client,
+            nonce,
+            decoded_evidence,
+            key_id,
+            expected_report_data=expected_report_data,
+        )
     elif tee_type == "intel-tdx":
-        result = tdx_vm_verify(redis_client, nonce, decoded_evidence, key_id)
+        result = tdx_vm_verify(
+            redis_client,
+            nonce,
+            decoded_evidence,
+            key_id,
+            expected_report_data=expected_report_data,
+        )
     else:
         logger.error(f"Unsupported TEE type: {tee_type}")
         return False, "Unsupported TEE type"

--- a/tests/test_tas_vm.py
+++ b/tests/test_tas_vm.py
@@ -1,0 +1,505 @@
+#
+# TEE Attestation Service - Tests for tas_vm verification functions
+#
+# Copyright 2026 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# This file is part of the TEE Attestation Service.
+#
+
+import base64
+import hashlib
+from unittest.mock import MagicMock, patch
+
+from tas.tas_vm import gpu_vm_verify, vm_verify
+
+# ── gpu_vm_verify tests ─────────────────────────────────────────────
+
+
+class TestGpuVmVerify:
+    """Tests for the gpu_vm_verify stub function."""
+
+    def test_empty_evidence_returns_error(self):
+        """Empty base64 payload should be rejected."""
+        empty_b64 = base64.b64encode(b"").decode()
+        ok, err = gpu_vm_verify("nvidia-hopper", empty_b64, 0)
+        assert ok is False
+        assert "empty evidence" in err
+
+    def test_valid_evidence_returns_not_implemented(self):
+        """Non-empty evidence should return a 'not implemented' error (stub)."""
+        evidence_b64 = base64.b64encode(b"\x01\x02\x03").decode()
+        ok, err = gpu_vm_verify("nvidia-hopper", evidence_b64, 0)
+        assert ok is False
+        assert "not yet implemented" in err
+
+    def test_invalid_base64_returns_error(self):
+        """Invalid base64 should be caught and return an error."""
+        ok, err = gpu_vm_verify("nvidia-hopper", "!!!not-base64!!!", 0)
+        assert ok is False
+        assert "verification error" in err
+
+    def test_device_index_in_error_message(self):
+        """Device index should appear in the error message."""
+        evidence_b64 = base64.b64encode(b"\xaa").decode()
+        ok, err = gpu_vm_verify("nvidia-hopper", evidence_b64, 42)
+        assert ok is False
+        assert "42" in err
+
+    def test_tee_type_in_error_message(self):
+        """GPU TEE type should appear in the error message."""
+        evidence_b64 = base64.b64encode(b"\xaa").decode()
+        ok, err = gpu_vm_verify("nvidia-hopper", evidence_b64, 0)
+        assert ok is False
+        assert "nvidia-hopper" in err
+
+
+# ── vm_verify input validation tests ────────────────────────────────
+
+
+class TestVmVerifyInputValidation:
+    """Tests for vm_verify input validation (before TEE dispatch)."""
+
+    VALID_EVIDENCE_B64 = base64.b64encode(b"\x01\x02\x03").decode()
+
+    def test_empty_nonce_rejected(self):
+        ok, err = vm_verify(
+            MagicMock(), "", "amd-sev-snp", self.VALID_EVIDENCE_B64, "k1"
+        )
+        assert ok is False
+        assert "Nonce" in err
+
+    def test_none_nonce_rejected(self):
+        ok, err = vm_verify(
+            MagicMock(), None, "amd-sev-snp", self.VALID_EVIDENCE_B64, "k1"
+        )
+        assert ok is False
+        assert "Nonce" in err
+
+    def test_invalid_tee_type_rejected(self):
+        ok, err = vm_verify(
+            MagicMock(), "abc123", "bad-type", self.VALID_EVIDENCE_B64, "k1"
+        )
+        assert ok is False
+        assert "TEE type" in err
+
+    def test_invalid_base64_evidence_rejected(self):
+        ok, err = vm_verify(MagicMock(), "abc123", "amd-sev-snp", "!!!bad!!!", "k1")
+        assert ok is False
+        assert "invalid" in err.lower()
+
+    def test_empty_evidence_rejected(self):
+        empty_b64 = base64.b64encode(b"").decode()
+        ok, err = vm_verify(MagicMock(), "abc123", "amd-sev-snp", empty_b64, "k1")
+        assert ok is False
+        assert "empty" in err.lower()
+
+
+# ── vm_verify report_data_binding tests ─────────────────────────────
+
+
+class TestVmVerifyReportDataBinding:
+    """Tests for the report_data_binding computation in vm_verify."""
+
+    NONCE = "test-nonce-1234"
+    TEE_EVIDENCE_B64 = base64.b64encode(b"\xde\xad\xbe\xef").decode()
+    WRAPPING_KEY = b"\x00" * 32
+    KEY_ID = "test-key"
+
+    @patch("tas.tas_vm.sev_vm_verify")
+    def test_binding_computes_sha512(self, mock_sev):
+        """With report_data_binding=True, expected_report_data should be SHA-512."""
+        mock_sev.return_value = (True, None)
+
+        vm_verify(
+            MagicMock(),
+            self.NONCE,
+            "amd-sev-snp",
+            self.TEE_EVIDENCE_B64,
+            self.KEY_ID,
+            wrapping_key=self.WRAPPING_KEY,
+            report_data_binding=True,
+        )
+
+        call_kwargs = mock_sev.call_args
+        expected = hashlib.sha512(
+            self.NONCE.encode("utf-8") + self.WRAPPING_KEY
+        ).digest()
+        assert call_kwargs.kwargs["expected_report_data"] == expected
+
+    @patch("tas.tas_vm.sev_vm_verify")
+    def test_no_binding_uses_nonce(self, mock_sev):
+        """Without binding, expected_report_data should be the raw nonce bytes."""
+        mock_sev.return_value = (True, None)
+
+        vm_verify(
+            MagicMock(),
+            self.NONCE,
+            "amd-sev-snp",
+            self.TEE_EVIDENCE_B64,
+            self.KEY_ID,
+        )
+
+        call_kwargs = mock_sev.call_args
+        assert call_kwargs.kwargs["expected_report_data"] == self.NONCE.encode("utf-8")
+
+    @patch("tas.tas_vm.sev_vm_verify")
+    def test_binding_false_uses_nonce(self, mock_sev):
+        """report_data_binding=False should use the raw nonce even with wrapping_key."""
+        mock_sev.return_value = (True, None)
+
+        vm_verify(
+            MagicMock(),
+            self.NONCE,
+            "amd-sev-snp",
+            self.TEE_EVIDENCE_B64,
+            self.KEY_ID,
+            wrapping_key=self.WRAPPING_KEY,
+            report_data_binding=False,
+        )
+
+        call_kwargs = mock_sev.call_args
+        assert call_kwargs.kwargs["expected_report_data"] == self.NONCE.encode("utf-8")
+
+    @patch("tas.tas_vm.sev_vm_verify")
+    def test_binding_true_no_wrapping_key_uses_nonce(self, mock_sev):
+        """report_data_binding=True without wrapping_key should fall back to nonce."""
+        mock_sev.return_value = (True, None)
+
+        vm_verify(
+            MagicMock(),
+            self.NONCE,
+            "amd-sev-snp",
+            self.TEE_EVIDENCE_B64,
+            self.KEY_ID,
+            wrapping_key=None,
+            report_data_binding=True,
+        )
+
+        call_kwargs = mock_sev.call_args
+        assert call_kwargs.kwargs["expected_report_data"] == self.NONCE.encode("utf-8")
+
+    @patch("tas.tas_vm.tdx_vm_verify")
+    def test_binding_dispatches_to_tdx(self, mock_tdx):
+        """Binding should work for intel-tdx as well."""
+        mock_tdx.return_value = (True, None)
+
+        vm_verify(
+            MagicMock(),
+            self.NONCE,
+            "intel-tdx",
+            self.TEE_EVIDENCE_B64,
+            self.KEY_ID,
+            wrapping_key=self.WRAPPING_KEY,
+            report_data_binding=True,
+        )
+
+        call_kwargs = mock_tdx.call_args
+        expected = hashlib.sha512(
+            self.NONCE.encode("utf-8") + self.WRAPPING_KEY
+        ).digest()
+        assert call_kwargs.kwargs["expected_report_data"] == expected
+
+
+# ── vm_verify return value propagation tests ────────────────────────
+
+
+class TestVmVerifyReturnPropagation:
+    """Tests that vm_verify correctly returns the result from TEE verifiers."""
+
+    NONCE = "prop-nonce"
+    TEE_EVIDENCE_B64 = base64.b64encode(b"\xab\xcd").decode()
+    KEY_ID = "prop-key"
+
+    @patch("tas.tas_vm.sev_vm_verify")
+    def test_sev_success_propagated(self, mock_sev):
+        """vm_verify should return (True, None) when sev_vm_verify succeeds."""
+        mock_sev.return_value = (True, None)
+        ok, err = vm_verify(
+            MagicMock(), self.NONCE, "amd-sev-snp", self.TEE_EVIDENCE_B64, self.KEY_ID
+        )
+        assert ok is True
+        assert err is None
+
+    @patch("tas.tas_vm.sev_vm_verify")
+    def test_sev_failure_propagated(self, mock_sev):
+        """vm_verify should return (False, error) when sev_vm_verify fails."""
+        mock_sev.return_value = (False, "SEV verification failed")
+        ok, err = vm_verify(
+            MagicMock(), self.NONCE, "amd-sev-snp", self.TEE_EVIDENCE_B64, self.KEY_ID
+        )
+        assert ok is False
+        assert err == "SEV verification failed"
+
+    @patch("tas.tas_vm.tdx_vm_verify")
+    def test_tdx_success_propagated(self, mock_tdx):
+        """vm_verify should return (True, None) when tdx_vm_verify succeeds."""
+        mock_tdx.return_value = (True, None)
+        ok, err = vm_verify(
+            MagicMock(), self.NONCE, "intel-tdx", self.TEE_EVIDENCE_B64, self.KEY_ID
+        )
+        assert ok is True
+        assert err is None
+
+    @patch("tas.tas_vm.tdx_vm_verify")
+    def test_tdx_failure_propagated(self, mock_tdx):
+        """vm_verify should return (False, error) when tdx_vm_verify fails."""
+        mock_tdx.return_value = (False, "TDX verification failed")
+        ok, err = vm_verify(
+            MagicMock(), self.NONCE, "intel-tdx", self.TEE_EVIDENCE_B64, self.KEY_ID
+        )
+        assert ok is False
+        assert err == "TDX verification failed"
+
+
+# ── vm_verify GPU evidence tests ────────────────────────────────────
+
+
+class TestVmVerifyGpuEvidence:
+    """Tests for GPU evidence handling in vm_verify."""
+
+    NONCE = "gpu-test-nonce"
+    TEE_EVIDENCE_B64 = base64.b64encode(b"\xca\xfe").decode()
+    WRAPPING_KEY = b"\x11" * 16
+    KEY_ID = "gpu-key"
+    GPU_EVIDENCE_RAW = b"\xaa\xbb\xcc"
+    GPU_EVIDENCE_B64 = base64.b64encode(GPU_EVIDENCE_RAW).decode()
+
+    def test_gpu_evidence_too_many_rejected(self):
+        """More than 16 GPU entries should be rejected."""
+        gpu_evidence = [
+            {
+                "tee-type": "nvidia-hopper",
+                "tee-evidence": self.GPU_EVIDENCE_B64,
+                "device-index": i,
+            }
+            for i in range(17)
+        ]
+        ok, err = vm_verify(
+            MagicMock(),
+            self.NONCE,
+            "amd-sev-snp",
+            self.TEE_EVIDENCE_B64,
+            self.KEY_ID,
+            wrapping_key=self.WRAPPING_KEY,
+            report_data_binding=True,
+            gpu_evidence=gpu_evidence,
+        )
+        assert ok is False
+        assert "max 16" in err
+
+    def test_gpu_evidence_exactly_16_passes_cap(self):
+        """Exactly 16 GPU entries should not be rejected by the cap."""
+        gpu_evidence = [
+            {
+                "tee-type": "nvidia-hopper",
+                "tee-evidence": self.GPU_EVIDENCE_B64,
+                "device-index": i,
+            }
+            for i in range(16)
+        ]
+        ok, err = vm_verify(
+            MagicMock(),
+            self.NONCE,
+            "amd-sev-snp",
+            self.TEE_EVIDENCE_B64,
+            self.KEY_ID,
+            wrapping_key=self.WRAPPING_KEY,
+            report_data_binding=True,
+            gpu_evidence=gpu_evidence,
+        )
+        assert ok is False
+        # Error should be from gpu_vm_verify stub, not the cap
+        assert "max 16" not in err
+
+    def test_gpu_failure_stops_verification(self):
+        """If a GPU fails verification, vm_verify should return its error."""
+        gpu_evidence = [
+            {
+                "tee-type": "nvidia-hopper",
+                "tee-evidence": self.GPU_EVIDENCE_B64,
+                "device-index": 0,
+            },
+        ]
+        ok, err = vm_verify(
+            MagicMock(),
+            self.NONCE,
+            "amd-sev-snp",
+            self.TEE_EVIDENCE_B64,
+            self.KEY_ID,
+            wrapping_key=self.WRAPPING_KEY,
+            report_data_binding=True,
+            gpu_evidence=gpu_evidence,
+        )
+        assert ok is False
+        assert "not yet implemented" in err
+
+    @patch("tas.tas_vm.gpu_vm_verify", return_value=(True, None))
+    @patch("tas.tas_vm.sev_vm_verify")
+    def test_gpu_hashes_included_in_binding(self, mock_sev, mock_gpu):
+        """GPU evidence SHA-512 hashes should be included in the binding."""
+        mock_sev.return_value = (True, None)
+
+        gpu0_raw = b"\xaa\xbb"
+        gpu1_raw = b"\xcc\xdd"
+        gpu_evidence = [
+            {
+                "tee-type": "nvidia-hopper",
+                "tee-evidence": base64.b64encode(gpu1_raw).decode(),
+                "device-index": 1,
+            },
+            {
+                "tee-type": "nvidia-hopper",
+                "tee-evidence": base64.b64encode(gpu0_raw).decode(),
+                "device-index": 0,
+            },
+        ]
+
+        vm_verify(
+            MagicMock(),
+            self.NONCE,
+            "amd-sev-snp",
+            self.TEE_EVIDENCE_B64,
+            self.KEY_ID,
+            wrapping_key=self.WRAPPING_KEY,
+            report_data_binding=True,
+            gpu_evidence=gpu_evidence,
+        )
+
+        # Build expected hash: sorted by device-index (0 first, then 1)
+        hash_input = self.NONCE.encode("utf-8") + self.WRAPPING_KEY
+        hash_input += hashlib.sha512(gpu0_raw).digest()
+        hash_input += hashlib.sha512(gpu1_raw).digest()
+        expected = hashlib.sha512(hash_input).digest()
+
+        call_kwargs = mock_sev.call_args
+        assert call_kwargs.kwargs["expected_report_data"] == expected
+
+    @patch("tas.tas_vm.gpu_vm_verify", return_value=(True, None))
+    @patch("tas.tas_vm.sev_vm_verify")
+    def test_gpu_evidence_sorted_by_device_index(self, mock_sev, mock_gpu):
+        """GPU evidence should be sorted by device-index for deterministic hashing."""
+        mock_sev.return_value = (True, None)
+
+        gpu_entries = [
+            {
+                "tee-type": "t",
+                "tee-evidence": base64.b64encode(b"gpu2").decode(),
+                "device-index": 2,
+            },
+            {
+                "tee-type": "t",
+                "tee-evidence": base64.b64encode(b"gpu0").decode(),
+                "device-index": 0,
+            },
+            {
+                "tee-type": "t",
+                "tee-evidence": base64.b64encode(b"gpu1").decode(),
+                "device-index": 1,
+            },
+        ]
+
+        vm_verify(
+            MagicMock(),
+            self.NONCE,
+            "amd-sev-snp",
+            self.TEE_EVIDENCE_B64,
+            self.KEY_ID,
+            wrapping_key=self.WRAPPING_KEY,
+            report_data_binding=True,
+            gpu_evidence=gpu_entries,
+        )
+
+        # gpu_vm_verify should have been called in sorted order: 0, 1, 2
+        calls = mock_gpu.call_args_list
+        device_indices = [c.args[2] for c in calls]
+        assert device_indices == [0, 1, 2]
+
+    def test_gpu_evidence_without_binding_ignored(self):
+        """GPU evidence without report_data_binding should not trigger GPU verify."""
+        gpu_evidence = [
+            {
+                "tee-type": "nvidia-hopper",
+                "tee-evidence": self.GPU_EVIDENCE_B64,
+                "device-index": 0,
+            },
+        ]
+        with patch("tas.tas_vm.sev_vm_verify") as mock_sev, patch(
+            "tas.tas_vm.gpu_vm_verify"
+        ) as mock_gpu:
+            mock_sev.return_value = (True, None)
+
+            vm_verify(
+                MagicMock(),
+                self.NONCE,
+                "amd-sev-snp",
+                self.TEE_EVIDENCE_B64,
+                self.KEY_ID,
+                wrapping_key=self.WRAPPING_KEY,
+                report_data_binding=False,
+                gpu_evidence=gpu_evidence,
+            )
+
+            mock_gpu.assert_not_called()
+
+    @patch("tas.tas_vm.gpu_vm_verify", return_value=(True, None))
+    @patch("tas.tas_vm.sev_vm_verify")
+    def test_binding_without_gpu_evidence_no_gpu_verify(self, mock_sev, mock_gpu):
+        """Binding without gpu_evidence should not call gpu_vm_verify."""
+        mock_sev.return_value = (True, None)
+
+        vm_verify(
+            MagicMock(),
+            self.NONCE,
+            "amd-sev-snp",
+            self.TEE_EVIDENCE_B64,
+            self.KEY_ID,
+            wrapping_key=self.WRAPPING_KEY,
+            report_data_binding=True,
+            gpu_evidence=None,
+        )
+
+        mock_gpu.assert_not_called()
+
+        # expected_report_data should be SHA-512(nonce || wrapping_key) with no GPU hashes
+        expected = hashlib.sha512(
+            self.NONCE.encode("utf-8") + self.WRAPPING_KEY
+        ).digest()
+        call_kwargs = mock_sev.call_args
+        assert call_kwargs.kwargs["expected_report_data"] == expected
+
+    @patch("tas.tas_vm.gpu_vm_verify")
+    @patch("tas.tas_vm.sev_vm_verify")
+    def test_second_gpu_failure_after_first_passes(self, mock_sev, mock_gpu):
+        """If the second GPU fails, its error should be returned."""
+        mock_gpu.side_effect = [
+            (True, None),  # GPU 0 passes
+            (False, "GPU 1 attestation invalid"),  # GPU 1 fails
+        ]
+
+        gpu_evidence = [
+            {
+                "tee-type": "t",
+                "tee-evidence": base64.b64encode(b"g0").decode(),
+                "device-index": 0,
+            },
+            {
+                "tee-type": "t",
+                "tee-evidence": base64.b64encode(b"g1").decode(),
+                "device-index": 1,
+            },
+        ]
+
+        ok, err = vm_verify(
+            MagicMock(),
+            self.NONCE,
+            "amd-sev-snp",
+            self.TEE_EVIDENCE_B64,
+            self.KEY_ID,
+            wrapping_key=self.WRAPPING_KEY,
+            report_data_binding=True,
+            gpu_evidence=gpu_evidence,
+        )
+
+        assert ok is False
+        assert "GPU 1" in err


### PR DESCRIPTION
Added wrapping key and GPU evidence support to the attestation verification pipeline.

Changes:
- Add expected_report_data parameter to sev_vm_verify and tdx_vm_verify to support SHA-512 report-data binding (nonce || wrapping_key [|| GPU hashes])
- Add gpu_vm_verify stub for per-GPU attestation evidence verification
- Extend vm_verify with wrapping_key, report_data_binding, and gpu_evidence parameters
- Update get_secret route in app.py to pass wrapping key, report-data binding flag, and GPU evidence to vm_verify
- Improve docstrings across all verification functions
- Add unit tests in test/test_tas_vm.py

Note: GPU attestation is still a stub and returns an error.