### PR TITLE
Fix: Return correct HTTP status codes for client errors

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,6 +23,7 @@ from flask import Flask, jsonify, request
 from tas.auth import authenticate_request, init_client_auth, init_management_auth
 from tas.config_loader import load_configuration
 from tas.deprecated_routes import deprecated_policy_bp
+from tas.error_handlers import register_error_handlers
 from tas.management_routes import management_bp
 from tas.tas_logging import configure_external_logging, setup_logging
 from tas.tas_vm import vm_verify
@@ -99,12 +100,7 @@ def log_response_info(response):
     return response
 
 
-@app.errorhandler(Exception)
-def handle_exception(e):
-    logger.error(
-        f"Unhandled exception in {request.method} {request.path}: {e}", exc_info=True
-    )
-    return jsonify({"error": "Internal server error"}), 500
+register_error_handlers(app)
 
 
 # Optionally add an extra plugin directory to sys.path

--- a/tas/error_handlers.py
+++ b/tas/error_handlers.py
@@ -1,0 +1,41 @@
+#
+# TEE Attestation Service
+#
+# Copyright 2026 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# This file is part of the TEE Attestation Service.
+# See LICENSE file for details.
+#
+
+import logging
+
+from flask import jsonify, request
+from werkzeug.exceptions import HTTPException
+
+logger = logging.getLogger("tas")
+
+
+def handle_exception(e):
+    """Global exception handler for the TAS Flask application.
+
+    Returns proper HTTP status codes for client errors (4xx)
+    and generic 500 for genuine server errors.
+    """
+    # Handle Flask/Werkzeug HTTP exceptions
+    if isinstance(e, HTTPException):
+        logger.warning(
+            f"HTTP {e.code}: {request.method} {request.path} - {e.description}"
+        )
+        return jsonify({"error": e.description or "Request error"}), e.code
+
+    # All other exceptions are server errors
+    logger.error(
+        f"Unhandled exception in {request.method} {request.path}: {e}", exc_info=True
+    )
+    return jsonify({"error": "Internal server error"}), 500
+
+
+def register_error_handlers(app):
+    """Register the global exception handler on a Flask app."""
+    app.register_error_handler(Exception, handle_exception)

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,137 @@
+#
+# TEE Attestation Service - Tests for Error Handling
+#
+# Copyright 2026 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# This file is part of the TEE Attestation Service.
+#
+
+import pytest
+from flask import Flask, jsonify
+from werkzeug.exceptions import BadRequest, Forbidden, HTTPException, Unauthorized
+
+from tas.error_handlers import register_error_handlers
+
+
+@pytest.fixture()
+def app():
+    """Create a test Flask app using the actual error handler from tas."""
+    test_app = Flask(__name__)
+    test_app.config["TESTING"] = True
+
+    # Register the real error handler from tas/error_handlers.py
+    register_error_handlers(test_app)
+
+    # Route that works normally
+    @test_app.route("/ok")
+    def ok():
+        return jsonify({"status": "ok"}), 200
+
+    # Route that raises a generic (non-HTTP) exception
+    @test_app.route("/server-error")
+    def server_error():
+        raise RuntimeError("something broke internally")
+
+    # Route that raises a 400 Bad Request
+    @test_app.route("/bad-request")
+    def bad_request():
+        raise BadRequest("Missing required field")
+
+    # Route that raises a 401 Unauthorized
+    @test_app.route("/unauthorized")
+    def unauthorized():
+        raise Unauthorized("Invalid credentials")
+
+    # Route that raises a 403 Forbidden
+    @test_app.route("/forbidden")
+    def forbidden():
+        raise Forbidden("Access denied")
+
+    # Route that raises an HTTPException with description=None
+    @test_app.route("/no-description")
+    def no_description():
+        exc = HTTPException()
+        exc.code = 422
+        exc.description = None
+        raise exc
+
+    return test_app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+class TestHTTPExceptionHandling:
+    """Verify that HTTPException subclasses return their correct status codes."""
+
+    def test_not_found_returns_404(self, client):
+        resp = client.get("/nonexistent-route")
+        assert resp.status_code == 404
+        data = resp.get_json()
+        assert "error" in data
+
+    def test_bad_request_returns_400(self, client):
+        resp = client.get("/bad-request")
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data["error"] == "Missing required field"
+
+    def test_unauthorized_returns_401(self, client):
+        resp = client.get("/unauthorized")
+        assert resp.status_code == 401
+        data = resp.get_json()
+        assert data["error"] == "Invalid credentials"
+
+    def test_forbidden_returns_403(self, client):
+        resp = client.get("/forbidden")
+        assert resp.status_code == 403
+        data = resp.get_json()
+        assert data["error"] == "Access denied"
+
+    def test_method_not_allowed_returns_405(self, client):
+        resp = client.post("/ok")
+        assert resp.status_code == 405
+        data = resp.get_json()
+        assert "error" in data
+
+    def test_http_exception_with_none_description(self, client):
+        resp = client.get("/no-description")
+        assert resp.status_code == 422
+        data = resp.get_json()
+        assert data["error"] == "Request error"
+
+    def test_http_exception_response_is_json(self, client):
+        resp = client.get("/nonexistent-route")
+        assert resp.content_type == "application/json"
+
+
+class TestGenericExceptionHandling:
+    """Verify that non-HTTP exceptions return 500 with a generic message."""
+
+    def test_runtime_error_returns_500(self, client):
+        resp = client.get("/server-error")
+        assert resp.status_code == 500
+        data = resp.get_json()
+        assert data["error"] == "Internal server error"
+
+    def test_server_error_does_not_leak_details(self, client):
+        resp = client.get("/server-error")
+        data = resp.get_json()
+        assert "something broke" not in data["error"]
+        assert "RuntimeError" not in data["error"]
+
+    def test_server_error_response_is_json(self, client):
+        resp = client.get("/server-error")
+        assert resp.content_type == "application/json"
+
+
+class TestNormalRoutes:
+    """Sanity check: normal routes still work as expected."""
+
+    def test_ok_route_returns_200(self, client):
+        resp = client.get("/ok")
+        assert resp.status_code == 200
+        assert resp.get_json() == {"status": "ok"}


### PR DESCRIPTION
Update global error handler to catch `werkzeug.exceptions.HTTPException` and return the specific status code (e.g., 404, 400) instead of a generic 500 Internal Server Error.