### PR TITLE
feat: configure Redis persistence at startup and add Redis AUTH support

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   push:
     branches: [main]
-    
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,94 +18,496 @@ jobs:
         include:
           - python-version: "3.10"
             port: "5000"
+            redis_port: "6370"
           - python-version: "3.11"
             port: "5001"
+            redis_port: "6371"
           - python-version: "3.12"
             port: "5002"
+            redis_port: "6372"
           - python-version: "3.13"
             port: "5003"
+            redis_port: "6373"
           - python-version: "3.14"
             port: "5004"
+            redis_port: "6374"
 
     steps:
       - uses: actions/checkout@v5
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      # You can test your matrix by printing the current Python version
+
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
 
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y redis-server
+          sudo apt-get install -y redis-server iproute2 psmisc
           redis-server --version
           pip install --upgrade pip
           git clone https://github.com/TEE-Attestation/sev_pytools.git
-          cd sev_pytools
-          pip install .
-          cd ..
+          cd sev_pytools && pip install . && cd ..
           git clone https://github.com/TEE-Attestation/tdx_pytools.git
-          cd tdx_pytools
-          pip install .
-          cd ..
+          cd tdx_pytools && pip install . && cd ..
           pip install -r requirements.txt
-      
-      - name: python compile check
-        run: |
-           python -m compileall -q -o 2  ./
-        
-
-      - name: Test with pytest
-        run: |
           pip install pytest pytest-cov
-          python -m pytest tests/ -v
+
+      - name: Compile check
+        run: python -m compileall -q -o 2 ./
+
+      - name: Unit tests
+        run: python -m pytest tests/ -v
 
       - name: Test demo signer
         run: |
           cd ./certs/policy
           python demo_signer.py ./sev_example_policy.json
-          cd ../../
 
-      - name: install ss command
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y iproute2
+      # ----------------------------------------------------------------
+      # Smoke tests — verify TAS starts under Flask and Gunicorn
+      # ----------------------------------------------------------------
 
-      - name: run application for 1 second with flask
+      - name: Smoke test (Flask)
         run: |
+          redis-cli -p ${{ matrix.redis_port }} ping 2>/dev/null \
+            || redis-server --port ${{ matrix.redis_port }} --daemonize yes
+          for i in $(seq 1 10); do
+            redis-cli -p ${{ matrix.redis_port }} ping 2>/dev/null | grep -q PONG && break
+            sleep 0.5
+          done
           setsid flask run --no-reload -h localhost -p ${{ matrix.port }} 2>&1 &
           PID=$!
-          sleep 1
+          for i in $(seq 1 20); do
+            curl -sf -H "X-API-KEY: $TAS_API_KEY" http://localhost:${{ matrix.port }}/version > /dev/null 2>&1 && break
+            sleep 0.5
+          done
           if ! kill -0 $PID 2>/dev/null; then
             echo "Flask exited early — startup failure"
             exit 1
           fi
           kill -- -$PID 2>/dev/null || true
           sleep 1
-          sudo ss --kill state listening src :${{ matrix.port }}
+          fuser -k ${{ matrix.port }}/tcp 2>/dev/null || true
         env:
           APP_ENV: "production"
           DEBUG: "false"
+          TAS_REDIS_PORT: "${{ matrix.redis_port }}"
           TAS_API_KEY: "our-secure-api-key-asdfg-12345-zxcvb-qwerty-lkjhg-56789-a1s23-56"
-          TAS_MANAGEMENT_API_KEY:  "mgmt-our-secure-api-key-asdfg-12345-zxcvb-qwerty-lkjhg-56789-a1s23-56"
-      
-      - name: run application for 1 second with gunicorn
+          TAS_MANAGEMENT_API_KEY: "mgmt-our-secure-api-key-asdfg-12345-zxcvb-qwerty-lkjhg-56789-a1s23-56"
+
+      - name: Smoke test (Gunicorn)
         run: |
-          setsid gunicorn -w 4 -b localhost:${{matrix.port}} app:app &
+          redis-cli -p ${{ matrix.redis_port }} ping 2>/dev/null \
+            || redis-server --port ${{ matrix.redis_port }} --daemonize yes
+          for i in $(seq 1 10); do
+            redis-cli -p ${{ matrix.redis_port }} ping 2>/dev/null | grep -q PONG && break
+            sleep 0.5
+          done
+          setsid gunicorn -w 4 -b localhost:${{ matrix.port }} app:app &
           PID=$!
-          sleep 1
+          for i in $(seq 1 20); do
+            curl -sf -H "X-API-KEY: $TAS_API_KEY" http://localhost:${{ matrix.port }}/version > /dev/null 2>&1 && break
+            sleep 0.5
+          done
           if ! kill -0 $PID 2>/dev/null; then
             echo "Gunicorn exited early — startup failure"
             exit 1
           fi
           kill -- -$PID 2>/dev/null || true
           sleep 1
-          sudo ss --kill state listening src :${{ matrix.port }}
+          fuser -k ${{ matrix.port }}/tcp 2>/dev/null || true
         env:
           APP_ENV: "production"
           DEBUG: "false"
+          TAS_REDIS_PORT: "${{ matrix.redis_port }}"
           TAS_API_KEY: "our-secure-api-key-asdfg-12345-zxcvb-qwerty-lkjhg-56789-a1s23-56"
           TAS_MANAGEMENT_API_KEY: "mgmt-our-secure-api-key-asdfg-12345-zxcvb-qwerty-lkjhg-56789-a1s23-56"
+
+      # ----------------------------------------------------------------
+      # Redis persistence integration tests
+      #
+      # Verify TAS enables AOF + RDB persistence on a bare Redis via
+      # CONFIG SET, persists settings via CONFIG REWRITE, and supports
+      # Redis AUTH.
+      # ----------------------------------------------------------------
+
+      - name: "Test A: TAS enables persistence on bare Redis (default)"
+        run: |
+          set -e
+          redis-cli -p ${{ matrix.redis_port }} SHUTDOWN NOSAVE 2>/dev/null || true
+          sleep 1
+
+          # Start Redis with NO persistence — simulates out-of-box state
+          rm -rf /tmp/redis-test-${{ matrix.redis_port }} && mkdir -p /tmp/redis-test-${{ matrix.redis_port }}
+          printf "port ${{ matrix.redis_port }}\ndir /tmp/redis-test-${{ matrix.redis_port }}\n" > /tmp/redis-${{ matrix.redis_port }}.conf
+          redis-server /tmp/redis-${{ matrix.redis_port }}.conf --daemonize yes
+          for i in $(seq 1 10); do redis-cli -p ${{ matrix.redis_port }} ping 2>/dev/null | grep -q PONG && break; sleep 0.5; done
+
+          # Confirm Redis starts without persistence
+          AOF_BEFORE=$(redis-cli -p ${{ matrix.redis_port }} CONFIG GET appendonly | tail -1)
+          echo "Before TAS: appendonly=$AOF_BEFORE"
+          if [ "$AOF_BEFORE" != "no" ]; then
+            echo "FAIL: expected appendonly=no before TAS"
+            exit 1
+          fi
+
+          # Start TAS — TAS_REDIS_PERSISTENCE defaults to true
+          setsid flask run --no-reload -h localhost -p ${{ matrix.port }} 2>&1 &
+          TAS_PID=$!
+          # Wait for TAS to be ready (up to 10s)
+          for i in $(seq 1 20); do
+            curl -sf -H "X-API-KEY: $TAS_API_KEY" http://localhost:${{ matrix.port }}/version > /dev/null 2>&1 && break
+            sleep 0.5
+          done
+          if ! kill -0 $TAS_PID 2>/dev/null; then
+            echo "FAIL: TAS exited early"; exit 1
+          fi
+
+          # Verify TAS enabled AOF via CONFIG SET
+          AOF_AFTER=$(redis-cli -p ${{ matrix.redis_port }} CONFIG GET appendonly | tail -1)
+          if [ "$AOF_AFTER" != "yes" ]; then
+            echo "FAIL: appendonly='$AOF_AFTER', expected 'yes'"; exit 1
+          fi
+          echo "PASS: appendonly = yes"
+
+          # Verify appendfsync = everysec
+          FSYNC=$(redis-cli -p ${{ matrix.redis_port }} CONFIG GET appendfsync | tail -1)
+          if [ "$FSYNC" != "everysec" ]; then
+            echo "FAIL: appendfsync='$FSYNC', expected 'everysec'"; exit 1
+          fi
+          echo "PASS: appendfsync = everysec"
+
+          # Verify RDB save schedule was set
+          SAVE_AFTER=$(redis-cli -p ${{ matrix.redis_port }} CONFIG GET save | tail -1)
+          if [ -z "$SAVE_AFTER" ]; then
+            echo "FAIL: save schedule is empty after TAS start"; exit 1
+          fi
+          echo "PASS: RDB save schedule='$SAVE_AFTER'"
+
+          # Check CONFIG REWRITE wrote settings to config file
+          cat /tmp/redis-${{ matrix.redis_port }}.conf
+          if grep -q "^appendonly" /tmp/redis-${{ matrix.redis_port }}.conf; then
+            echo "PASS: CONFIG REWRITE persisted settings"
+          else
+            echo "WARN: CONFIG REWRITE did not persist (may lack permission)"
+          fi
+
+          # Cleanup
+          kill -- -$TAS_PID 2>/dev/null || true
+          sleep 1
+          fuser -k ${{ matrix.port }}/tcp 2>/dev/null || true
+          redis-cli -p ${{ matrix.redis_port }} SHUTDOWN NOSAVE 2>/dev/null || true
+          rm -rf /tmp/redis-test-${{ matrix.redis_port }}
+        env:
+          TAS_REDIS_PORT: "${{ matrix.redis_port }}"
+          TAS_API_KEY: "our-secure-api-key-asdfg-12345-zxcvb-qwerty-lkjhg-56789-a1s23-56"
+          TAS_MANAGEMENT_API_KEY: "mgmt-our-secure-api-key-asdfg-12345-zxcvb-qwerty-lkjhg-56789-a1s23-56"
+          TAS_ENFORCE_SIGNED_POLICIES: "false"
+
+      - name: "Test B: Policy data survives Redis restart"
+        run: |
+          set -e
+          redis-cli -p ${{ matrix.redis_port }} SHUTDOWN NOSAVE 2>/dev/null || true
+          sleep 1
+
+          # Start Redis with persistence pre-enabled (known-good config)
+          rm -rf /tmp/redis-test-${{ matrix.redis_port }} && mkdir -p /tmp/redis-test-${{ matrix.redis_port }}
+          printf "port ${{ matrix.redis_port }}\ndir /tmp/redis-test-${{ matrix.redis_port }}\nappendonly yes\nappendfsync everysec\n" \
+            > /tmp/redis-${{ matrix.redis_port }}.conf
+          redis-server /tmp/redis-${{ matrix.redis_port }}.conf --daemonize yes
+          for i in $(seq 1 10); do redis-cli -p ${{ matrix.redis_port }} ping 2>/dev/null | grep -q PONG && break; sleep 0.5; done
+
+          # Start TAS
+          setsid flask run --no-reload -h localhost -p ${{ matrix.port }} 2>&1 &
+          TAS_PID=$!
+          # Wait for TAS to be ready (up to 10s)
+          for i in $(seq 1 20); do
+            curl -sf -H "X-API-KEY: $TAS_API_KEY" http://localhost:${{ matrix.port }}/version > /dev/null 2>&1 && break
+            sleep 0.5
+          done
+          if ! kill -0 $TAS_PID 2>/dev/null; then
+            echo "FAIL: TAS exited early"; exit 1
+          fi
+
+          # Store a policy
+          HTTP_CODE=$(curl -s -o /tmp/store_resp.json -w "%{http_code}" \
+            -X POST "http://localhost:${{ matrix.port }}/management/policy/v0/store" \
+            -H "Content-Type: application/json" \
+            -H "X-MANAGEMENT-API-KEY: $TAS_MANAGEMENT_API_KEY" \
+            -d '{
+              "policy_type": "SEV",
+              "key_id": "ci-persist-test",
+              "policy": {
+                "metadata": {
+                  "name": "CI Persistence Test",
+                  "version": "1.0",
+                  "description": "Integration test policy"
+                },
+                "validation_rules": {"host_data": {"exact_match": "test"}}
+              }
+            }')
+          if [ "$HTTP_CODE" -ne 200 ] && [ "$HTTP_CODE" -ne 201 ]; then
+            echo "FAIL: Store policy returned HTTP $HTTP_CODE"
+            cat /tmp/store_resp.json; exit 1
+          fi
+          echo "PASS: Policy stored (HTTP $HTTP_CODE)"
+
+          # Confirm policy exists
+          redis-cli -p ${{ matrix.redis_port }} GET "policy:SEV:ci-persist-test" | grep -q "CI Persistence Test"
+          echo "PASS: Policy found in Redis"
+
+          # Wait for AOF fsync (appendfsync everysec)
+          sleep 2
+          echo "Data dir before restart:"
+          ls -la /tmp/redis-test-${{ matrix.redis_port }}/
+
+          # Kill TAS, cold restart Redis (SHUTDOWN NOSAVE — forces AOF-only recovery)
+          kill -- -$TAS_PID 2>/dev/null || true
+          sleep 1
+          fuser -k ${{ matrix.port }}/tcp 2>/dev/null || true
+          redis-cli -p ${{ matrix.redis_port }} SHUTDOWN NOSAVE 2>/dev/null || true
+          sleep 1
+
+          # Restart Redis
+          redis-server /tmp/redis-${{ matrix.redis_port }}.conf --daemonize yes
+          for i in $(seq 1 10); do redis-cli -p ${{ matrix.redis_port }} ping 2>/dev/null | grep -q PONG && break; sleep 0.5; done
+
+          # Verify policy survived
+          RESULT=$(redis-cli -p ${{ matrix.redis_port }} GET "policy:SEV:ci-persist-test")
+          if echo "$RESULT" | grep -q "CI Persistence Test"; then
+            echo "PASS: Policy survived Redis restart via AOF"
+          else
+            echo "FAIL: Policy lost after restart"
+            echo "Got: $RESULT"
+            ls -laR /tmp/redis-test-${{ matrix.redis_port }}/ || true
+            exit 1
+          fi
+
+          # Cleanup
+          redis-cli -p ${{ matrix.redis_port }} SHUTDOWN NOSAVE 2>/dev/null || true
+          rm -rf /tmp/redis-test-${{ matrix.redis_port }}
+        env:
+          TAS_REDIS_PORT: "${{ matrix.redis_port }}"
+          TAS_API_KEY: "our-secure-api-key-asdfg-12345-zxcvb-qwerty-lkjhg-56789-a1s23-56"
+          TAS_MANAGEMENT_API_KEY: "mgmt-our-secure-api-key-asdfg-12345-zxcvb-qwerty-lkjhg-56789-a1s23-56"
+          TAS_REDIS_PERSISTENCE: "true"
+          TAS_ENFORCE_SIGNED_POLICIES: "false"
+
+      - name: "Test C: Persistence opt-out (TAS_REDIS_PERSISTENCE=false)"
+        run: |
+          set -e
+          redis-cli -p ${{ matrix.redis_port }} SHUTDOWN NOSAVE 2>/dev/null || true
+          sleep 1
+
+          # Start Redis with NO persistence
+          rm -rf /tmp/redis-test-${{ matrix.redis_port }} && mkdir -p /tmp/redis-test-${{ matrix.redis_port }}
+          printf "port ${{ matrix.redis_port }}\ndir /tmp/redis-test-${{ matrix.redis_port }}\n" > /tmp/redis-${{ matrix.redis_port }}.conf
+          redis-server /tmp/redis-${{ matrix.redis_port }}.conf --daemonize yes
+          for i in $(seq 1 10); do redis-cli -p ${{ matrix.redis_port }} ping 2>/dev/null | grep -q PONG && break; sleep 0.5; done
+
+          # Start TAS with persistence disabled
+          setsid flask run --no-reload -h localhost -p ${{ matrix.port }} 2>&1 &
+          TAS_PID=$!
+          # Wait for TAS to be ready (up to 10s)
+          for i in $(seq 1 20); do
+            curl -sf -H "X-API-KEY: $TAS_API_KEY" http://localhost:${{ matrix.port }}/version > /dev/null 2>&1 && break
+            sleep 0.5
+          done
+          if ! kill -0 $TAS_PID 2>/dev/null; then
+            echo "FAIL: TAS exited early"; exit 1
+          fi
+
+          # Verify TAS did NOT enable AOF
+          AOF=$(redis-cli -p ${{ matrix.redis_port }} CONFIG GET appendonly | tail -1)
+          if [ "$AOF" != "no" ]; then
+            echo "FAIL: appendonly='$AOF', expected 'no'"; exit 1
+          fi
+          echo "PASS: appendonly = no (TAS did not touch Redis)"
+
+          # Verify config file was not modified
+          if grep -q "appendonly" /tmp/redis-${{ matrix.redis_port }}.conf; then
+            echo "FAIL: config file modified despite persistence disabled"; exit 1
+          fi
+          echo "PASS: Config file unchanged"
+
+          # Verify /management/status reflects opt-out
+          RESPONSE=$(curl -s \
+            "http://localhost:${{ matrix.port }}/management/status" \
+            -H "X-MANAGEMENT-API-KEY: $TAS_MANAGEMENT_API_KEY")
+          echo "Status: $RESPONSE"
+
+          echo "$RESPONSE" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          assert data['redis_persistence_active'] is False, f\"expected false, got {data['redis_persistence_active']}\"
+          print('PASS: redis_persistence_active = false')
+          assert data['config_rewrite_succeeded'] is None, f\"expected null, got {data['config_rewrite_succeeded']}\"
+          print('PASS: config_rewrite_succeeded = null (not attempted)')
+          "
+
+          # Cleanup
+          kill -- -$TAS_PID 2>/dev/null || true
+          sleep 1
+          fuser -k ${{ matrix.port }}/tcp 2>/dev/null || true
+          redis-cli -p ${{ matrix.redis_port }} SHUTDOWN NOSAVE 2>/dev/null || true
+          rm -rf /tmp/redis-test-${{ matrix.redis_port }}
+        env:
+          TAS_REDIS_PORT: "${{ matrix.redis_port }}"
+          TAS_API_KEY: "our-secure-api-key-asdfg-12345-zxcvb-qwerty-lkjhg-56789-a1s23-56"
+          TAS_MANAGEMENT_API_KEY: "mgmt-our-secure-api-key-asdfg-12345-zxcvb-qwerty-lkjhg-56789-a1s23-56"
+          TAS_REDIS_PERSISTENCE: "false"
+          TAS_ENFORCE_SIGNED_POLICIES: "false"
+
+      - name: "Test D: /management/status endpoint"
+        run: |
+          set -e
+          redis-cli -p ${{ matrix.redis_port }} SHUTDOWN NOSAVE 2>/dev/null || true
+          sleep 1
+
+          rm -rf /tmp/redis-test-${{ matrix.redis_port }} && mkdir -p /tmp/redis-test-${{ matrix.redis_port }}
+          printf "port ${{ matrix.redis_port }}\ndir /tmp/redis-test-${{ matrix.redis_port }}\n" > /tmp/redis-${{ matrix.redis_port }}.conf
+          redis-server /tmp/redis-${{ matrix.redis_port }}.conf --daemonize yes
+          for i in $(seq 1 10); do redis-cli -p ${{ matrix.redis_port }} ping 2>/dev/null | grep -q PONG && break; sleep 0.5; done
+
+          setsid flask run --no-reload -h localhost -p ${{ matrix.port }} 2>&1 &
+          TAS_PID=$!
+          # Wait for TAS to be ready (up to 10s)
+          for i in $(seq 1 20); do
+            curl -sf -H "X-API-KEY: $TAS_API_KEY" http://localhost:${{ matrix.port }}/version > /dev/null 2>&1 && break
+            sleep 0.5
+          done
+          if ! kill -0 $TAS_PID 2>/dev/null; then
+            echo "FAIL: TAS exited early"; exit 1
+          fi
+
+          # Check response fields
+          RESPONSE=$(curl -s \
+            "http://localhost:${{ matrix.port }}/management/status" \
+            -H "X-MANAGEMENT-API-KEY: $TAS_MANAGEMENT_API_KEY")
+          echo "Status: $RESPONSE"
+
+          echo "$RESPONSE" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          assert data['redis_persistence_active'] is True, f\"expected true, got {data['redis_persistence_active']}\"
+          print('PASS: redis_persistence_active = true')
+          assert 'config_rewrite_succeeded' in data, 'config_rewrite_succeeded field missing'
+          print('PASS: config_rewrite_succeeded field present')
+          "
+
+          # Must require management API key
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            "http://localhost:${{ matrix.port }}/management/status")
+          if [ "$HTTP_CODE" -eq 401 ]; then
+            echo "PASS: 401 without API key"
+          else
+            echo "FAIL: got $HTTP_CODE, expected 401"; exit 1
+          fi
+
+          # /version must NOT contain redis_persistence_active
+          VERSION=$(curl -s \
+            "http://localhost:${{ matrix.port }}/version" \
+            -H "X-API-KEY: $TAS_API_KEY")
+          echo "Version: $VERSION"
+          if echo "$VERSION" | grep -q '"redis_persistence_active"'; then
+            echo "FAIL: /version should not contain redis_persistence_active"; exit 1
+          fi
+          echo "PASS: /version clean"
+
+          # Cleanup
+          kill -- -$TAS_PID 2>/dev/null || true
+          sleep 1
+          fuser -k ${{ matrix.port }}/tcp 2>/dev/null || true
+          redis-cli -p ${{ matrix.redis_port }} SHUTDOWN NOSAVE 2>/dev/null || true
+          rm -rf /tmp/redis-test-${{ matrix.redis_port }}
+        env:
+          TAS_REDIS_PORT: "${{ matrix.redis_port }}"
+          TAS_API_KEY: "our-secure-api-key-asdfg-12345-zxcvb-qwerty-lkjhg-56789-a1s23-56"
+          TAS_MANAGEMENT_API_KEY: "mgmt-our-secure-api-key-asdfg-12345-zxcvb-qwerty-lkjhg-56789-a1s23-56"
+          TAS_REDIS_PERSISTENCE: "true"
+          TAS_ENFORCE_SIGNED_POLICIES: "false"
+
+      - name: "Test E: Redis password authentication"
+        run: |
+          set -e
+          redis-cli -p ${{ matrix.redis_port }} SHUTDOWN NOSAVE 2>/dev/null || true
+          sleep 1
+
+          rm -rf /tmp/redis-test-${{ matrix.redis_port }} && mkdir -p /tmp/redis-test-${{ matrix.redis_port }}
+          printf "port ${{ matrix.redis_port }}\ndir /tmp/redis-test-${{ matrix.redis_port }}\nrequirepass ci-test-password\n" \
+            > /tmp/redis-auth-${{ matrix.redis_port }}.conf
+          redis-server /tmp/redis-auth-${{ matrix.redis_port }}.conf --daemonize yes
+          for i in $(seq 1 10); do redis-cli -p ${{ matrix.redis_port }} -a ci-test-password ping 2>/dev/null | grep -q PONG && break; sleep 0.5; done
+
+          # TAS with correct password
+          setsid flask run --no-reload -h localhost -p ${{ matrix.port }} 2>&1 &
+          TAS_PID=$!
+          # Wait for TAS to be ready (up to 10s)
+          for i in $(seq 1 20); do
+            curl -sf -H "X-API-KEY: $TAS_API_KEY" http://localhost:${{ matrix.port }}/version > /dev/null 2>&1 && break
+            sleep 0.5
+          done
+          if ! kill -0 $TAS_PID 2>/dev/null; then
+            echo "FAIL: TAS exited early (auth failure?)"; exit 1
+          fi
+          echo "PASS: TAS connected to password-protected Redis"
+
+          # Store a policy
+          HTTP_CODE=$(curl -s -o /tmp/auth_store.json -w "%{http_code}" \
+            -X POST "http://localhost:${{ matrix.port }}/management/policy/v0/store" \
+            -H "Content-Type: application/json" \
+            -H "X-MANAGEMENT-API-KEY: $TAS_MANAGEMENT_API_KEY" \
+            -d '{
+              "policy_type": "SEV",
+              "key_id": "ci-auth-test",
+              "policy": {
+                "metadata": {"name": "Auth Test", "version": "1.0", "description": "test"},
+                "validation_rules": {}
+              }
+            }')
+          if [ "$HTTP_CODE" -ne 200 ] && [ "$HTTP_CODE" -ne 201 ]; then
+            echo "FAIL: Store returned HTTP $HTTP_CODE"
+            cat /tmp/auth_store.json; exit 1
+          fi
+          echo "PASS: Policy stored (HTTP $HTTP_CODE)"
+
+          # Retrieve policy
+          HTTP_CODE=$(curl -s -o /tmp/auth_get.json -w "%{http_code}" \
+            "http://localhost:${{ matrix.port }}/management/policy/v0/get/policy:SEV:ci-auth-test" \
+            -H "X-MANAGEMENT-API-KEY: $TAS_MANAGEMENT_API_KEY")
+          if [ "$HTTP_CODE" -ne 200 ]; then
+            echo "FAIL: Get returned HTTP $HTTP_CODE"; exit 1
+          fi
+          echo "PASS: Policy retrieved (HTTP $HTTP_CODE)"
+
+          kill -- -$TAS_PID 2>/dev/null || true
+          sleep 1
+          fuser -k ${{ matrix.port }}/tcp 2>/dev/null || true
+
+          # TAS without password should fail on a protected Redis
+          echo "Testing TAS without password (should fail)..."
+          TAS_REDIS_PASSWORD="" setsid flask run --no-reload -h localhost -p ${{ matrix.port }} 2>&1 &
+          NO_AUTH_PID=$!
+          sleep 3
+          if kill -0 $NO_AUTH_PID 2>/dev/null; then
+            echo "WARN: TAS started without password"
+            kill -- -$NO_AUTH_PID 2>/dev/null || true
+          else
+            echo "PASS: TAS failed to start without password"
+          fi
+
+          # Cleanup
+          fuser -k ${{ matrix.port }}/tcp 2>/dev/null || true
+          redis-cli -p ${{ matrix.redis_port }} -a ci-test-password SHUTDOWN NOSAVE 2>/dev/null || true
+          rm -rf /tmp/redis-test-${{ matrix.redis_port }}
+        env:
+          TAS_REDIS_PORT: "${{ matrix.redis_port }}"
+          TAS_API_KEY: "our-secure-api-key-asdfg-12345-zxcvb-qwerty-lkjhg-56789-a1s23-56"
+          TAS_MANAGEMENT_API_KEY: "mgmt-our-secure-api-key-asdfg-12345-zxcvb-qwerty-lkjhg-56789-a1s23-56"
+          TAS_REDIS_PASSWORD: "ci-test-password"
+          TAS_REDIS_PERSISTENCE: "true"
+          TAS_ENFORCE_SIGNED_POLICIES: "false"

--- a/app.py
+++ b/app.py
@@ -136,21 +136,63 @@ discovered_plugins = {
 
 # Initialize Redis client
 try:
-    redis_client = redis.StrictRedis(
-        host=app.config["TAS_REDIS_HOST"],  # Redis server address
-        port=app.config["TAS_REDIS_PORT"],  # Redis server port
-        decode_responses=True,  # Ensures responses are returned as strings
-    )
+    redis_kwargs = {
+        "host": app.config["TAS_REDIS_HOST"],
+        "port": app.config["TAS_REDIS_PORT"],
+        "decode_responses": True,
+    }
+    redis_password = app.config.get("TAS_REDIS_PASSWORD", "")
+    if redis_password:
+        redis_kwargs["password"] = redis_password
+
+    redis_client = redis.StrictRedis(**redis_kwargs)
     # Test the connection to ensure Redis is reachable
     redis_client.ping()
     logger.info("Successful Connection to Redis Server")
+    if redis_password:
+        logger.info("Redis AUTH enabled")
+    else:
+        logger.info("Redis AUTH not configured (no TAS_REDIS_PASSWORD set)")
 except redis.ConnectionError as e:
     raise RuntimeError(f"Failed to connect to the Redis server: {e}")
 except Exception as e:
     raise RuntimeError(f"An unexpected error occurred while initializing Redis: {e}")
 
-# Expose Redis client to blueprints
+# Configure Redis persistence (AOF + RDB) if enabled
+_redis_config_rewrite_ok = None  # None = persistence not attempted
+if app.config.get("TAS_REDIS_PERSISTENCE", True):
+    try:
+        redis_client.config_set("appendonly", "yes")
+        redis_client.config_set("appendfsync", "everysec")
+        redis_client.config_set("save", "3600 1 300 100 60 10000")
+        logger.info("Redis persistence configured (AOF + RDB)")
+        try:
+            redis_client.config_rewrite()
+            _redis_config_rewrite_ok = True
+            logger.info(
+                "Redis CONFIG REWRITE successful — settings persisted to Redis config file"
+            )
+        except redis.ResponseError as e:
+            _redis_config_rewrite_ok = False
+            logger.warning(
+                "Redis CONFIG REWRITE failed — if Redis restarts independently, "
+                "persistence settings will be lost and policies WILL BE DESTROYED. "
+                "Either grant CONFIG REWRITE permission or configure persistence "
+                f"in your redis.conf manually: {e}"
+            )
+    except redis.ResponseError as e:
+        _redis_config_rewrite_ok = False
+        logger.warning(
+            f"Could not configure Redis persistence (CONFIG SET rejected): {e}. "
+            "Policies WILL BE LOST if Redis restarts without persistence. "
+            "Ensure your Redis server has persistence enabled independently."
+        )
+else:
+    logger.info("Redis persistence disabled by TAS_REDIS_PERSISTENCE=false")
+
+# Expose Redis client and persistence state to blueprints
 app.extensions["redis"] = redis_client
+app.extensions["redis_config_rewrite_ok"] = _redis_config_rewrite_ok
 
 # Register blueprints
 app.register_blueprint(management_bp)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -124,6 +124,8 @@ Stored in Flask's config; set directly via env without prefix:
 | TAS_NONCE_EXPIRATION_SECONDS | int | `120` | No | Number of seconds a nonce remains valid after creation. Nonces older than this are rejected during attestation verification. |
 | TAS_REDIS_HOST | str | `"localhost"` | No | Hostname or IP address of the Redis server used for nonce storage, certificate caching, and policy storage. |
 | TAS_REDIS_PORT | int | `6379` | No | Port number of the Redis server. |
+| TAS_REDIS_PASSWORD | str | `""` | No | Redis AUTH password. When set, TAS authenticates to Redis on connection. Always set via environment variable, never in config files. |
+| TAS_REDIS_PERSISTENCE | bool | `true` | No | When `true`, TAS configures Redis AOF + RDB persistence at startup via `CONFIG SET`. Set to `false` if your Redis is externally managed or you want to use your own `redis.conf` settings. Check `GET /management/status` for runtime persistence state. See [REDIS_PERSISTENCE.md](REDIS_PERSISTENCE.md) for details. |
 | TAS_PLUGIN_PREFIX | str | `"tas_kbm"` | No | Module name prefix used to discover KBM (Key Broker Module) plugins at startup. Only modules whose name starts with this prefix are loaded. |
 | TAS_KBM_PLUGIN | str | `"tas_kbm_mock"` | No | Exact module name of the KBM plugin to activate. Must match one of the discovered plugins. Controls which key broker backend TAS uses (e.g., mock, KMIP, KMIP-JSON). |
 | TAS_KBM_CONFIG_FILE | str | `"./config/kbm_mock_config.yaml"` | No | Path to the configuration file passed to the selected KBM plugin during initialisation. The format depends on the plugin (e.g., PyKMIP conf, KMIP-JSON YAML). |
@@ -175,6 +177,8 @@ export TAS_OVERRIDE__logging__file="/var/log/tas.log"
 export TAS_CONFIG_CLASS=config.ProductionConfig
 export TAS_REDIS_HOST=redis.internal
 export TAS_REDIS_PORT=6380
+export TAS_REDIS_PASSWORD='your-secure-redis-password'
+export TAS_REDIS_PERSISTENCE=true
 export TAS_NONCE_EXPIRATION_SECONDS=180
 export TAS_KBM_CONFIG_FILE=./config/pykmip/alt.conf
 export TAS_KBM_PLUGIN=tas_kbm_kmip_json
@@ -184,6 +188,29 @@ export TAS_POLICY_TRUST=./certs/policy
 export TAS_API_KEY='...(>=64 chars)...'
 export TAS_MANAGEMENT_API_KEY='...(>=64 chars)...'
 ```
+
+## Management status endpoint
+
+`GET /management/status` returns the runtime Redis persistence state. Requires
+the `X-MANAGEMENT-API-KEY` header.
+
+```json
+{
+  "redis_persistence_active": true,
+  "config_rewrite_succeeded": true
+}
+```
+
+| Field | Type | Values | Meaning |
+|-------|------|--------|---------|
+| `redis_persistence_active` | bool \| string | `true` | AOF + RDB persistence is currently enabled in Redis |
+| | | `false` | Persistence is not enabled |
+| | | `"unknown"` | Could not query Redis (connection issue) |
+| `config_rewrite_succeeded` | bool \| null | `true` | CONFIG REWRITE succeeded — settings survive Redis restart |
+| | | `false` | CONFIG REWRITE failed — settings active but not persisted to redis.conf |
+| | | `null` | Persistence not attempted (`TAS_REDIS_PERSISTENCE=false`) |
+
+See [REDIS_PERSISTENCE.md](REDIS_PERSISTENCE.md) for operator guidance.
 
 ## Run TAS with ProductionConfig or DevelopmentConfig
 

--- a/docs/REDIS_PERSISTENCE.md
+++ b/docs/REDIS_PERSISTENCE.md
@@ -1,0 +1,116 @@
+# Redis Persistence
+
+TAS stores security policies in Redis. By default, TAS automatically configures
+Redis persistence at startup so policies survive Redis and host restarts. This
+is done via Redis `CONFIG SET` commands — no manual Redis configuration is needed.
+
+## What TAS configures by default
+
+When `TAS_REDIS_PERSISTENCE=true` (the default), TAS issues these commands at
+startup:
+
+| Command | Effect |
+|---------|--------|
+| `CONFIG SET appendonly yes` | Enable AOF (Append-Only File). Every write is logged to an on-disk journal. |
+| `CONFIG SET appendfsync everysec` | Fsync the AOF once per second. At most 1 second of data loss on crash. |
+| `CONFIG SET save "3600 1 300 100 60 10000"` | Enable RDB snapshots as a backup safety net (every 60 s if ≥10 000 keys changed, every 300 s if ≥100, every 3600 s if ≥1). |
+
+After CONFIG SET, TAS calls `CONFIG REWRITE` to write the settings into
+Redis's own config file so they survive independent Redis restarts.
+
+**If CONFIG REWRITE fails** (e.g. Redis has no config file, or ACLs block
+the command), TAS logs a warning and continues. Persistence is active for
+the current Redis session, but if Redis restarts independently the settings
+revert to defaults and **policies will be lost**. Check the
+`GET /management/status` endpoint — a `"config_rewrite_succeeded": false` response
+means you must either grant CONFIG REWRITE permission or configure
+persistence in your `redis.conf` manually.
+
+## Monitoring persistence status
+
+The `GET /management/status` endpoint (requires management API key) returns:
+
+```json
+{
+  "redis_persistence_active": true,
+  "config_rewrite_succeeded": true
+}
+```
+
+| Field | Values | Meaning |
+|-------|--------|---------|
+| `redis_persistence_active` | `true` / `false` / `"unknown"` | Whether AOF is currently enabled in Redis |
+| `config_rewrite_succeeded` | `true` / `false` / `null` | Whether CONFIG REWRITE succeeded at startup. `null` means persistence was not attempted (`TAS_REDIS_PERSISTENCE=false`). |
+
+**Action required when `config_rewrite_succeeded` is `false`:**
+- Grant the Redis user `CONFIG REWRITE` permission, or
+- Add `appendonly yes` and `appendfsync everysec` to your `redis.conf` manually
+
+## What data is protected
+
+| Key pattern | TTL | Risk without persistence |
+|-------------|-----|--------------------------|
+| `policy:<type>:<id>` | None | **Lost forever** — must be re-uploaded manually |
+| `certs:*`, `crl:*`, `tdx_collateral:*` | 48 h | Re-fetched automatically on cache miss |
+| Nonces | 120 s | Ephemeral by design — no persistence needed |
+
+Policies are the critical data. Without persistence, a Redis restart silently
+destroys all stored attestation policies.
+
+## How to disable
+
+Set `TAS_REDIS_PERSISTENCE=false` in your environment or config file. TAS will
+not issue any `CONFIG SET` commands.
+
+You are then responsible for configuring Redis persistence yourself:
+
+- **Bare-metal**: edit `/etc/redis/redis.conf`, set `appendonly yes` and your
+  preferred `appendfsync` / `save` directives, then restart Redis.
+- **Docker**: mount a custom `redis.conf` into the container.
+- **Cloud-managed** (ElastiCache, Azure Cache, Memorystore): enable persistence
+  via the provider's dashboard. `CONFIG SET` is typically blocked on managed
+  services, so `TAS_REDIS_PERSISTENCE=false` is required. If TAS's CONFIG SET
+  is rejected, it logs a warning and continues — you must ensure persistence is
+  configured externally.
+
+## Alternative strategies
+
+### In-memory only (no persistence)
+
+Set `TAS_REDIS_PERSISTENCE=false` and do **not** configure Redis persistence.
+Policies are lost on restart. Use this if you have an external policy reload
+mechanism (CI/CD pipeline, management API script, or a policy-as-code workflow).
+
+### RDB-only
+
+Periodic full snapshots, larger data-loss window, simpler. In your `redis.conf`:
+
+```
+appendonly no
+save 3600 1 300 100 60 10000
+```
+
+### AOF with `appendfsync always`
+
+Maximum durability — fsync on every write, zero data loss. Slower throughput.
+In your `redis.conf`:
+
+```
+appendonly yes
+appendfsync always
+save ""
+```
+
+## Security considerations
+
+With persistence enabled, policies are written to disk as cleartext JSON in
+AOF and RDB files. To protect them:
+
+1. **File permissions**: `chmod 700 /var/lib/redis`, owned by the Redis user.
+2. **Signed policies**: Set `TAS_ENFORCE_SIGNED_POLICIES=true`. TAS re-verifies
+   policy signatures at attestation time, so tampered AOF/RDB data is rejected.
+3. **Redis authentication**: Set `TAS_REDIS_PASSWORD` to require AUTH.
+4. **Redis ACLs** (Redis 6+): Restrict the TAS user to only the commands it
+   needs.
+
+See [CONFIG.md](CONFIG.md) for the full configuration reference.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -255,6 +255,37 @@
         "required": [
           "version"
         ]
+      },
+      "StatusResponse": {
+        "type": "object",
+        "description": "Redis persistence status. redis_persistence_active is a live check of whether AOF is enabled in Redis (true/false, or \"unknown\" if the query fails). config_rewrite_succeeded indicates whether CONFIG REWRITE succeeded at startup (true/false, or null if persistence was not attempted).",
+        "properties": {
+          "redis_persistence_active": {
+            "description": "Whether Redis AOF + RDB persistence is currently active. \"unknown\" if Redis could not be queried.",
+            "oneOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "unknown"
+                ]
+              }
+            ],
+            "example": true
+          },
+          "config_rewrite_succeeded": {
+            "description": "Whether CONFIG REWRITE succeeded at startup. true = settings persisted to redis.conf, false = REWRITE failed (settings active but not persisted), null = persistence not attempted (TAS_REDIS_PERSISTENCE=false).",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
+          }
+        },
+        "required": [
+          "redis_persistence_active",
+          "config_rewrite_succeeded"
+        ]
       }
     },
     "headers": {
@@ -1076,6 +1107,42 @@
           },
           "404": {
             "description": "Policy not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/management/status": {
+      "get": {
+        "tags": [
+          "Management"
+        ],
+        "summary": "Get Redis persistence status",
+        "description": "Returns the current Redis persistence state and whether CONFIG REWRITE succeeded at TAS startup. Requires management API key.",
+        "security": [
+          {
+            "ManagementApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Persistence status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized \u2014 invalid or missing management API key",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -182,6 +182,29 @@ components:
           example: 0.1.0
       required:
       - version
+    StatusResponse:
+      type: object
+      description: Redis persistence status. redis_persistence_active is a live check of whether AOF is enabled in Redis (true/false,
+        or "unknown" if the query fails). config_rewrite_succeeded indicates whether CONFIG REWRITE succeeded at startup (true/false,
+        or null if persistence was not attempted).
+      properties:
+        redis_persistence_active:
+          description: Whether Redis AOF + RDB persistence is currently active. "unknown" if Redis could not be queried.
+          oneOf:
+          - type: boolean
+          - type: string
+            enum:
+            - unknown
+          example: true
+        config_rewrite_succeeded:
+          description: Whether CONFIG REWRITE succeeded at startup. true = settings persisted to redis.conf, false = REWRITE
+            failed (settings active but not persisted), null = persistence not attempted (TAS_REDIS_PERSISTENCE=false).
+          type: boolean
+          nullable: true
+          example: true
+      required:
+      - redis_persistence_active
+      - config_rewrite_succeeded
   headers:
     Deprecation:
       description: Indicates the endpoint is deprecated (RFC 8594)
@@ -651,6 +674,28 @@ paths:
                 $ref: '#/components/schemas/Error'
         '404':
           description: Policy not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /management/status:
+    get:
+      tags:
+      - Management
+      summary: Get Redis persistence status
+      description: Returns the current Redis persistence state and whether CONFIG REWRITE succeeded at TAS startup. Requires
+        management API key.
+      security:
+      - ManagementApiKeyAuth: []
+      responses:
+        '200':
+          description: Persistence status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '401':
+          description: Unauthorized — invalid or missing management API key
           content:
             application/json:
               schema:

--- a/tas/config.py
+++ b/tas/config.py
@@ -42,6 +42,8 @@ class BaseConfig:
     TAS_NONCE_EXPIRATION_SECONDS = int(os.getenv("TAS_NONCE_EXPIRATION_SECONDS", "120"))
     TAS_REDIS_HOST = os.getenv("TAS_REDIS_HOST", "localhost")
     TAS_REDIS_PORT = int(os.getenv("TAS_REDIS_PORT", "6379"))
+    TAS_REDIS_PASSWORD = os.getenv("TAS_REDIS_PASSWORD", "")
+    TAS_REDIS_PERSISTENCE = True
     TAS_PLUGIN_PREFIX = os.getenv("TAS_PLUGIN_PREFIX", "tas_kbm")
     # TODO fix this  to take the config file relative to app.py file
     TAS_KBM_CONFIG_FILE = os.getenv(

--- a/tas/config_loader.py
+++ b/tas/config_loader.py
@@ -34,9 +34,12 @@ KNOWN_TAS_KEYS = {
     "TAS_NONCE_EXPIRATION_SECONDS",
     "TAS_REDIS_HOST",
     "TAS_REDIS_PORT",
+    "TAS_REDIS_PASSWORD",
+    "TAS_REDIS_PERSISTENCE",
     "TAS_PLUGIN_PREFIX",
     "TAS_KBM_CONFIG_FILE",
     "TAS_KBM_PLUGIN",
+    "TAS_ENFORCE_SIGNED_POLICIES",
     "TAS_EXTRA_PLUGIN_DIR",
 }
 
@@ -200,11 +203,15 @@ def _load_trusted_keys(path: str):
 
 def apply_tas_env_overrides(app):
     # Direct overrides (exact match)
+    _SENSITIVE_KEYS = {"TAS_REDIS_PASSWORD", "TAS_API_KEY", "TAS_MANAGEMENT_API_KEY"}
     direct_overrides = []
     for key in KNOWN_TAS_KEYS:
         if key in os.environ:
             app.config[key] = _coerce(os.environ[key])
-            direct_overrides.append(f"{key}={app.config[key]}")
+            if key in _SENSITIVE_KEYS:
+                direct_overrides.append(f"{key}=***")
+            else:
+                direct_overrides.append(f"{key}={app.config[key]}")
 
     if direct_overrides:
         logger.debug(

--- a/tas/management_routes.py
+++ b/tas/management_routes.py
@@ -262,3 +262,27 @@ def delete_policy(policy_key):
     except Exception as e:
         logger.error(f"Error deleting policy: {e}")
         return jsonify({"error": "Failed to delete policy from Redis"}), 500
+
+
+@management_bp.route("/status", methods=["GET"])
+def status():
+    """Return operational status of the TAS management plane."""
+    auth_response = authenticate_management_request()
+    if auth_response:
+        return auth_response
+
+    redis_client = _get_redis()
+    try:
+        aof_config = redis_client.config_get("appendonly")
+        persistence_active = aof_config.get("appendonly") == "yes"
+    except Exception:
+        persistence_active = "unknown"
+
+    config_rewrite_ok = current_app.extensions.get("redis_config_rewrite_ok")
+
+    return jsonify(
+        {
+            "redis_persistence_active": persistence_active,
+            "config_rewrite_succeeded": config_rewrite_ok,
+        }
+    )

--- a/tests/test_management_routes.py
+++ b/tests/test_management_routes.py
@@ -63,6 +63,10 @@ class FakeRedis:
     def setex(self, key, ttl, value):
         self._store[key] = value
 
+    def config_get(self, key):
+        defaults = {"appendonly": "no"}
+        return {key: defaults.get(key, "")}
+
 
 @pytest.fixture()
 def app():
@@ -75,6 +79,7 @@ def app():
 
     fake_redis = FakeRedis()
     test_app.extensions["redis"] = fake_redis
+    test_app.extensions["redis_config_rewrite_ok"] = None
 
     init_client_auth(test_app)
     init_management_auth(test_app)
@@ -311,3 +316,46 @@ class TestKeySeparation:
     def test_management_route_accepts_mgmt_key(self, client, mgmt_headers):
         resp = client.get("/management/policy/v0/list", headers=mgmt_headers)
         assert resp.status_code == 200
+
+
+class TestStatusEndpoint:
+    """Tests for GET /management/status."""
+
+    def test_status_returns_persistence_info(self, client):
+        resp = client.get(
+            "/management/status",
+            headers={"X-MANAGEMENT-API-KEY": MGMT_API_KEY},
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "redis_persistence_active" in data
+        assert "config_rewrite_succeeded" in data
+
+    def test_status_reflects_config_rewrite_ok(self, app, client):
+        app.extensions["redis_config_rewrite_ok"] = True
+        resp = client.get(
+            "/management/status",
+            headers={"X-MANAGEMENT-API-KEY": MGMT_API_KEY},
+        )
+        data = resp.get_json()
+        assert data["config_rewrite_succeeded"] is True
+
+    def test_status_reflects_config_rewrite_failed(self, app, client):
+        app.extensions["redis_config_rewrite_ok"] = False
+        resp = client.get(
+            "/management/status",
+            headers={"X-MANAGEMENT-API-KEY": MGMT_API_KEY},
+        )
+        data = resp.get_json()
+        assert data["config_rewrite_succeeded"] is False
+
+    def test_status_requires_management_key(self, client):
+        resp = client.get("/management/status")
+        assert resp.status_code == 401
+
+    def test_status_rejects_wrong_key(self, client):
+        resp = client.get(
+            "/management/status",
+            headers={"X-MANAGEMENT-API-KEY": "wrong-key"},
+        )
+        assert resp.status_code == 401


### PR DESCRIPTION
TAS now programmatically enables Redis AOF + RDB persistence via CONFIG SET at startup, with CONFIG REWRITE to persist settings across independent Redis restarts.

New configuration:
- TAS_REDIS_PERSISTENCE (bool, default true) — opt out with "false"
- TAS_REDIS_PASSWORD (str) — Redis AUTH support

New endpoint:
- GET /management/status — returns redis_persistence and config_persisted (requires management API key)

Other changes:
- Add TAS_ENFORCE_SIGNED_POLICIES to KNOWN_TAS_KEYS for env overrides
- Redact sensitive keys (passwords, API keys) in config loader logs
- Add operator docs: docs/REDIS_PERSISTENCE.md, updated docs/CONFIG.md
- Add unit tests for /management/status endpoint
- Add Redis integration tests to CI workflow
- CI: per-build Redis ports to avoid collisions in shared runners