### PR TITLE
Rfc 8785 JSON canonicalization for signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,17 +80,17 @@ With TAS running you can use the [TAS agent](https://github.com/TEE-Attestation/
 
 ### Required Software
 
-- **Python***
+- **Python** (>= 3.8)
 - **Redis**
 
-*If you want to use the KMIP KBM plugin, ensure PyKMIP is installed. Note that PyKMIP does not work on Python 3.12 or later because it relies on ssl.wrap_socket(), which was removed in Python 3.12, so your venv will need a Python version between 3.7 and 3.11.
+*If you want to use the KMIP KBM plugin, ensure PyKMIP is installed. Note that PyKMIP does not work on Python 3.12 or later because it relies on ssl.wrap_socket(), which was removed in Python 3.12, so your venv will need a Python version between 3.8 and 3.11.
 
 ### Verify Prerequisites
 
 ```bash
 # Check Python installation
 python --version
-# For KMIP should show: Python 3.7.x - 3.11.x
+# For KMIP should show: Python 3.8.x - 3.11.x
 
 # Check Redis connectivity
 redis-cli ping

--- a/certs/policy/demo_signer.py
+++ b/certs/policy/demo_signer.py
@@ -7,13 +7,11 @@ import json
 import os
 import sys
 
+import rfc8785
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from cryptography.x509.oid import NameOID
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
-from tas.policy_helper import sort_dict_recursively
 
 
 def sign_policy_file(policy_file_path, private_key):
@@ -24,12 +22,9 @@ def sign_policy_file(policy_file_path, private_key):
             policy_data = json.load(f)
 
         measurements = policy_data["validation_rules"]
-        sorted_measurements = sort_dict_recursively(measurements)
 
-        # Convert to JSON bytes for signing
-        measurements_json = json.dumps(
-            sorted_measurements, sort_keys=True, separators=(",", ":")
-        ).encode("utf-8")
+        # Canonicalize for signing (RFC 8785 JCS)
+        measurements_json = rfc8785.dumps(measurements)
 
         # Create signature using PSS padding and SHA384 hash
         signature = private_key.sign(

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -127,6 +127,12 @@ Policy signing provides:
 - **Authentication**: Verifies policy creator
 - **Non-repudiation**: Prevents denial of policy authorship
 
+### How Signatures Work
+
+Before signing or verifying, TAS canonicalizes the policy JSON using [RFC 8785 (JSON Canonicalization Scheme / JCS)](https://www.rfc-editor.org/rfc/rfc8785). This ensures that logically equivalent JSON objects produce identical byte representations regardless of key ordering or whitespace. The canonicalized bytes are then signed with RSA using SHA-384 and either PSS or PKCS1v15 padding.
+
+> **Note:** Policies must be signed using RFC 8785 canonicalization. Any custom signing tool must canonicalize the policy to be signed with JCS before signing.
+
 ### Step 1: Use TAS Demo Signer
 
 TAS includes a demo signing tool that can generate keys automatically and sign policies. You can use the provided `demo_signer.py` or generate your own keys.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@
 [project]
 name = "TAS"
 version = "0.1.0-alpha"
+requires-python = ">=3.8"
 
 [tool.isort]
 profile = "black"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cryptography>=40.0.0
+rfc8785>=0.1.0
 pycryptodome>=3.15.0
 Flask>=3.0.0
 gunicorn>=20.0.0

--- a/tas/policy_helper.py
+++ b/tas/policy_helper.py
@@ -14,6 +14,7 @@ import json
 import logging
 import re
 
+import rfc8785
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
@@ -22,19 +23,6 @@ from .tas_logging import get_logger
 
 # Get logger for this module
 logger = get_logger(__name__)
-
-
-def sort_dict_recursively(obj):
-    """Recursively sort dictionaries and their nested dictionaries."""
-    # logger.debug(f"Sorting object of type: {type(obj)}")
-    if isinstance(obj, dict):
-        # logger.debug(f"Sorting dictionary with {len(obj)} keys")
-        return dict(sorted((k, sort_dict_recursively(v)) for k, v in obj.items()))
-    elif isinstance(obj, list):
-        # logger.debug(f"Sorting list with {len(obj)} items")
-        return [sort_dict_recursively(item) for item in obj]
-    else:
-        return obj
 
 
 def verify_policy_signature(policy_data, public_keys):
@@ -74,13 +62,10 @@ def verify_policy_signature(policy_data, public_keys):
         signature = base64.b64decode(signature_b64)
         logger.debug(f"Decoded signature length: {len(signature)} bytes")
 
-        # Extract and sort the validation rules (same as signing process)
-        logger.debug("Extracting and sorting validation rules")
+        # Canonicalize the validation rules (RFC 8785 JCS)
+        logger.debug("Canonicalizing validation rules")
         measurements = policy_data["validation_rules"]
-        sorted_measurements = sort_dict_recursively(measurements)
-        measurements_json = json.dumps(
-            sorted_measurements, sort_keys=True, separators=(",", ":")
-        ).encode("utf-8")
+        measurements_json = rfc8785.dumps(measurements)
         logger.debug(
             f"Prepared data for verification, length: {len(measurements_json)} bytes"
         )

--- a/tests/test_policy_helper.py
+++ b/tests/test_policy_helper.py
@@ -7,7 +7,6 @@
 # This file is part of the TEE Attestation Service.
 #
 # This module provides comprehensive unit tests for policy_helper.py, including:
-# - sort_dict_recursively: Testing recursive dictionary sorting functionality
 # - verify_policy_signature: Testing RSA signature verification with PSS/PKCS1v15 padding
 #   including edge cases, error handling, and multi-key scenarios
 #
@@ -17,60 +16,11 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+import rfc8785
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
-from tas.policy_helper import sort_dict_recursively, verify_policy_signature
-
-
-class TestSortDictRecursively:
-    """Test cases for sort_dict_recursively function."""
-
-    def test_sort_simple_dict(self):
-        """Test sorting a simple dictionary."""
-        input_dict = {"c": 3, "a": 1, "b": 2}
-        expected = {"a": 1, "b": 2, "c": 3}
-        result = sort_dict_recursively(input_dict)
-        assert result == expected
-
-    def test_sort_nested_dict(self):
-        """Test sorting nested dictionaries."""
-        input_dict = {"z": {"y": 2, "x": 1}, "a": {"c": 4, "b": 3}}
-        expected = {"a": {"b": 3, "c": 4}, "z": {"x": 1, "y": 2}}
-        result = sort_dict_recursively(input_dict)
-        assert result == expected
-
-    def test_sort_list_of_dicts(self):
-        """Test sorting list containing dictionaries."""
-        input_list = [{"b": 2, "a": 1}, {"d": 4, "c": 3}]
-        expected = [{"a": 1, "b": 2}, {"c": 3, "d": 4}]
-        result = sort_dict_recursively(input_list)
-        assert result == expected
-
-    def test_sort_mixed_nested_structure(self):
-        """Test sorting complex nested structure with dicts and lists."""
-        input_data = {
-            "z": [{"y": 2, "x": 1}, {"b": 4, "a": 3}],
-            "m": {"n": {"q": 6, "p": 5}, "l": [{"s": 8, "r": 7}]},
-        }
-        expected = {
-            "m": {"l": [{"r": 7, "s": 8}], "n": {"p": 5, "q": 6}},
-            "z": [{"x": 1, "y": 2}, {"a": 3, "b": 4}],
-        }
-        result = sort_dict_recursively(input_data)
-        assert result == expected
-
-    def test_sort_empty_structures(self):
-        """Test sorting empty dictionaries and lists."""
-        assert sort_dict_recursively({}) == {}
-        assert sort_dict_recursively([]) == []
-
-    def test_sort_list_with_mixed_types(self):
-        """Test sorting list with mixed types including dictionaries."""
-        input_list = [{"b": 2, "a": 1}, "string", 42, {"d": 4, "c": 3}]
-        expected = [{"a": 1, "b": 2}, "string", 42, {"c": 3, "d": 4}]
-        result = sort_dict_recursively(input_list)
-        assert result == expected
+from tas.policy_helper import verify_policy_signature
 
 
 class TestVerifyPolicySignature:
@@ -99,12 +49,8 @@ class TestVerifyPolicySignature:
 
     def create_valid_signature(self, policy_data, private_key, padding_scheme="PSS"):
         """Helper method to create a valid signature for test data."""
-        # Extract and sort validation rules
         measurements = policy_data["validation_rules"]
-        sorted_measurements = sort_dict_recursively(measurements)
-        measurements_json = json.dumps(
-            sorted_measurements, sort_keys=True, separators=(",", ":")
-        ).encode("utf-8")
+        measurements_json = rfc8785.dumps(measurements)
 
         # Create signature
         if padding_scheme == "PSS":


### PR DESCRIPTION
Fixes #27 

Changed to the [RFC 8785 (JSON Canonicalization Scheme / JCS)](https://www.rfc-editor.org/rfc/rfc8785) for policy signing. This will make standardising between TAS and custom tools and other languages easier.

This change also pushed the minimum python version to 3.8.

NOTE: Previous policies should still work and will have the same signature.

