### PR TITLE
Add signed_data behaviour for policy signing, default behaviour is al…

### DIFF
--- a/certs/policy/demo_signer.py
+++ b/certs/policy/demo_signer.py
@@ -21,14 +21,15 @@ def sign_policy_file(policy_file_path, private_key):
         with open(policy_file_path, "r") as f:
             policy_data = json.load(f)
 
-        measurements = policy_data["validation_rules"]
+        # Build the data to sign: all top-level fields except "signature" in case user wants to reuse a policy that is already signed
+        data_to_sign = {k: v for k, v in policy_data.items() if k != "signature"}
 
         # Canonicalize for signing (RFC 8785 JCS)
-        measurements_json = rfc8785.dumps(measurements)
+        data_json = rfc8785.dumps(data_to_sign)
 
         # Create signature using PSS padding and SHA384 hash
         signature = private_key.sign(
-            measurements_json,
+            data_json,
             padding.PSS(
                 mgf=padding.MGF1(hashes.SHA384()), salt_length=padding.PSS.MAX_LENGTH
             ),
@@ -158,7 +159,6 @@ def main():
                 "algorithm": "SHA384",
                 "padding": "PSS",
                 "value": signature_data,
-                "signed_data": "validation_rules",
             }
         }
 

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -100,7 +100,7 @@ Policies are stored in Redis and referenced during attestation validation to det
 | `algorithm` | string | Yes | Algorithm used |
 | `padding` | string | Yes | Padding (either PSS or PKCS1v15) |
 | `value` | string | Yes | Base64 encoded signature |
-| `signed_data` | string | No | Specifies which structures were signed, not implemented yet |
+| `signed_data` | string or list | No | Specifies which fields are signed. If omitted, the signature covers all top-level fields except `signature`. Can be a single field name (e.g. `"validation_rules"`) or a list (e.g. `["metadata", "validation_rules"]`). |
 
 ### TDX Specific Fields
 ##### TCB
@@ -130,6 +130,10 @@ Policy signing provides:
 ### How Signatures Work
 
 Before signing or verifying, TAS canonicalizes the policy JSON using [RFC 8785 (JSON Canonicalization Scheme / JCS)](https://www.rfc-editor.org/rfc/rfc8785). This ensures that logically equivalent JSON objects produce identical byte representations regardless of key ordering or whitespace. The canonicalized bytes are then signed with RSA using SHA-384 and either PSS or PKCS1v15 padding.
+
+By default, the signature covers **all top-level fields** in the policy (metadata, validation_rules, etc.) except the `signature` field itself. This means any change to the policy will invalidate the signature.
+
+If you need the signature to cover only specific fields, you can add a `signed_data` field to the signature object specifying which field(s) to sign. For example, `"signed_data": "validation_rules"` will sign only the validation rules, allowing metadata to be changed without invalidating the signature.
 
 > **Note:** Policies must be signed using RFC 8785 canonicalization. Any custom signing tool must canonicalize the policy to be signed with JCS before signing.
 
@@ -180,8 +184,7 @@ cat your-policy.json.sig
 #   "signature": {
 #     "algorithm": "SHA384",
 #     "padding": "PSS", 
-#     "value": "base64-encoded-signature...",
-#     "signed_data": "validation_rules"
+#     "value": "base64-encoded-signature..."
 #   }
 # }
 

--- a/tas/policy_helper.py
+++ b/tas/policy_helper.py
@@ -62,12 +62,50 @@ def verify_policy_signature(policy_data, public_keys):
         signature = base64.b64decode(signature_b64)
         logger.debug(f"Decoded signature length: {len(signature)} bytes")
 
-        # Canonicalize the validation rules (RFC 8785 JCS)
-        logger.debug("Canonicalizing validation rules")
-        measurements = policy_data["validation_rules"]
-        measurements_json = rfc8785.dumps(measurements)
+        # Determine what data is covered by the signature
+        signed_data_spec = signature_info.get("signed_data")
+
+        if signed_data_spec is not None:
+            # signed_data specified: sign only those fields
+            if isinstance(signed_data_spec, str):
+                signed_data_spec = [signed_data_spec]
+
+            if not isinstance(signed_data_spec, list) or not signed_data_spec:
+                logger.error(
+                    "signed_data must be a non-empty string or list of strings"
+                )
+                return False
+
+            logger.debug(f"Signature covers specified fields: {signed_data_spec}")
+            if len(signed_data_spec) == 1:
+                # Single field: canonicalize the field value directly (backward compatible)
+                field = signed_data_spec[0]
+                if field not in policy_data:
+                    logger.error(
+                        f"signed_data field '{field}' not found in policy data"
+                    )
+                    return False
+                data_to_verify = policy_data[field]
+            else:
+                # Multiple fields: build a dict of the specified fields
+                data_to_verify = {}
+                for field in sorted(signed_data_spec):
+                    if field not in policy_data:
+                        logger.error(
+                            f"signed_data field '{field}' not found in policy data"
+                        )
+                        return False
+                    data_to_verify[field] = policy_data[field]
+        else:
+            # Default: signature covers all top-level fields except "signature"
+            logger.debug(
+                "No signed_data specified, signature covers all fields except 'signature'"
+            )
+            data_to_verify = {k: v for k, v in policy_data.items() if k != "signature"}
+
+        signed_json = rfc8785.dumps(data_to_verify)
         logger.debug(
-            f"Prepared data for verification, length: {len(measurements_json)} bytes"
+            f"Prepared data for verification, length: {len(signed_json)} bytes"
         )
 
         # Determine padding scheme from signature info
@@ -84,7 +122,7 @@ def verify_policy_signature(policy_data, public_keys):
                     logger.debug("Using PSS padding for verification")
                     public_key.verify(
                         signature,
-                        measurements_json,
+                        signed_json,
                         padding.PSS(
                             mgf=padding.MGF1(hashes.SHA384()),
                             salt_length=padding.PSS.MAX_LENGTH,
@@ -95,7 +133,7 @@ def verify_policy_signature(policy_data, public_keys):
                     logger.debug("Using PKCS1v15 padding for verification")
                     public_key.verify(
                         signature,
-                        measurements_json,
+                        signed_json,
                         padding.PKCS1v15(),
                         hashes.SHA384(),
                     )

--- a/tests/test_policy_helper.py
+++ b/tests/test_policy_helper.py
@@ -35,7 +35,7 @@ class TestVerifyPolicySignature:
 
     @pytest.fixture
     def sample_policy_data(self):
-        """Sample policy data for testing."""
+        """Policy with signed_data targeting only validation_rules."""
         return {
             "metadata": {"name": "Test Policy", "version": "1.0"},
             "validation_rules": {
@@ -44,18 +44,62 @@ class TestVerifyPolicySignature:
                 "vmpl": {"exact_match": 0},
                 "debug": False,
             },
+            "signature": {
+                "algorithm": "SHA384",
+                "padding": "PSS",
+                "value": "",
+                "signed_data": "validation_rules",
+            },
+        }
+
+    @pytest.fixture
+    def default_signed_policy_data(self):
+        """Policy without signed_data — signature covers all fields."""
+        return {
+            "metadata": {"name": "Test Policy", "version": "1.0"},
+            "validation_rules": {
+                "measurement": {"exact_match": "12ab34cd56ef"},
+                "version": {"min_value": 3},
+            },
             "signature": {"algorithm": "SHA384", "padding": "PSS", "value": ""},
+        }
+
+    @pytest.fixture
+    def multi_signed_policy_data(self):
+        """Policy with signed_data as a list of multiple fields."""
+        return {
+            "metadata": {"name": "Test Policy", "version": "1.0"},
+            "validation_rules": {
+                "measurement": {"exact_match": "12ab34cd56ef"},
+            },
+            "signature": {
+                "algorithm": "SHA384",
+                "padding": "PSS",
+                "value": "",
+                "signed_data": ["metadata", "validation_rules"],
+            },
         }
 
     def create_valid_signature(self, policy_data, private_key, padding_scheme="PSS"):
         """Helper method to create a valid signature for test data."""
-        measurements = policy_data["validation_rules"]
-        measurements_json = rfc8785.dumps(measurements)
+        signed_data_spec = policy_data.get("signature", {}).get("signed_data")
+
+        if signed_data_spec is not None:
+            if isinstance(signed_data_spec, str):
+                signed_data_spec = [signed_data_spec]
+            if len(signed_data_spec) == 1:
+                data_to_sign = policy_data[signed_data_spec[0]]
+            else:
+                data_to_sign = {k: policy_data[k] for k in sorted(signed_data_spec)}
+        else:
+            data_to_sign = {k: v for k, v in policy_data.items() if k != "signature"}
+
+        data_json = rfc8785.dumps(data_to_sign)
 
         # Create signature
         if padding_scheme == "PSS":
             signature = private_key.sign(
-                measurements_json,
+                data_json,
                 padding.PSS(
                     mgf=padding.MGF1(hashes.SHA384()),
                     salt_length=padding.PSS.MAX_LENGTH,
@@ -64,7 +108,7 @@ class TestVerifyPolicySignature:
             )
         else:  # PKCS1v15
             signature = private_key.sign(
-                measurements_json,
+                data_json,
                 padding.PKCS1v15(),
                 hashes.SHA384(),
             )
@@ -327,3 +371,92 @@ class TestVerifyPolicySignature:
 
         assert result1 is True
         assert result2 is True
+
+    def test_default_signs_all_fields(self, rsa_key_pair, default_signed_policy_data):
+        """Test that without signed_data, signature covers all fields except signature."""
+        private_key, public_key = rsa_key_pair
+
+        signature_b64 = self.create_valid_signature(
+            default_signed_policy_data, private_key
+        )
+        default_signed_policy_data["signature"]["value"] = signature_b64
+
+        public_keys = [("RSA", "test_key.pem", public_key)]
+        result = verify_policy_signature(default_signed_policy_data, public_keys)
+        assert result is True
+
+    def test_default_metadata_change_breaks_signature(
+        self, rsa_key_pair, default_signed_policy_data
+    ):
+        """Test that modifying metadata breaks signature when no signed_data specified."""
+        private_key, public_key = rsa_key_pair
+
+        signature_b64 = self.create_valid_signature(
+            default_signed_policy_data, private_key
+        )
+        default_signed_policy_data["signature"]["value"] = signature_b64
+
+        # Modify metadata after signing
+        default_signed_policy_data["metadata"]["version"] = "2.0"
+
+        public_keys = [("RSA", "test_key.pem", public_key)]
+        result = verify_policy_signature(default_signed_policy_data, public_keys)
+        assert result is False
+
+    def test_signed_data_single_field_string(self, rsa_key_pair, sample_policy_data):
+        """Test signed_data as a single string field name."""
+        private_key, public_key = rsa_key_pair
+
+        signature_b64 = self.create_valid_signature(sample_policy_data, private_key)
+        sample_policy_data["signature"]["value"] = signature_b64
+
+        public_keys = [("RSA", "test_key.pem", public_key)]
+        result = verify_policy_signature(sample_policy_data, public_keys)
+        assert result is True
+
+    def test_signed_data_allows_metadata_change(self, rsa_key_pair, sample_policy_data):
+        """Test that with signed_data=validation_rules, changing metadata does not break sig."""
+        private_key, public_key = rsa_key_pair
+
+        signature_b64 = self.create_valid_signature(sample_policy_data, private_key)
+        sample_policy_data["signature"]["value"] = signature_b64
+
+        # Modify metadata after signing - should NOT break signature
+        sample_policy_data["metadata"]["version"] = "2.0"
+
+        public_keys = [("RSA", "test_key.pem", public_key)]
+        result = verify_policy_signature(sample_policy_data, public_keys)
+        assert result is True
+
+    def test_signed_data_list_of_fields(self, rsa_key_pair, multi_signed_policy_data):
+        """Test signed_data as a list of multiple field names."""
+        private_key, public_key = rsa_key_pair
+
+        signature_b64 = self.create_valid_signature(
+            multi_signed_policy_data, private_key
+        )
+        multi_signed_policy_data["signature"]["value"] = signature_b64
+
+        public_keys = [("RSA", "test_key.pem", public_key)]
+        result = verify_policy_signature(multi_signed_policy_data, public_keys)
+        assert result is True
+
+    def test_signed_data_missing_field(self, rsa_key_pair):
+        """Test that signed_data referencing a missing field returns False."""
+        _, public_key = rsa_key_pair
+
+        policy_data = {
+            "validation_rules": {
+                "measurement": {"exact_match": "12ab34cd56ef"},
+            },
+            "signature": {
+                "algorithm": "SHA384",
+                "padding": "PSS",
+                "value": base64.b64encode(b"test").decode("utf-8"),
+                "signed_data": "nonexistent_field",
+            },
+        }
+
+        public_keys = [("RSA", "test_key.pem", public_key)]
+        result = verify_policy_signature(policy_data, public_keys)
+        assert result is False


### PR DESCRIPTION
…l policy fields signed

- Added the previously unimplemented `signed_data` behaviour for policy signatures. Specified fields are now used to check the signature against
- Added a new default behaviour, if there is no `signed_data` field then all policy fields except the signature itself are used for signing. The demo_signer.py now uses this defualt behaviour

Note that pre-existing policies will still work as before, since the `signed_data` behaviour was temporarily hard-coded to use validation_rules which will be the same behaviour as now with validation_rules contained in signed_data.