### PR TITLE
Add policy_type and key_id fields to metadata in policies

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -239,16 +239,14 @@ jobs:
             -H "Content-Type: application/json" \
             -H "X-MANAGEMENT-API-KEY: $TAS_MANAGEMENT_API_KEY" \
             -d '{
-              "policy_type": "SEV",
-              "key_id": "ci-persist-test",
-              "policy": {
-                "metadata": {
-                  "name": "CI Persistence Test",
-                  "version": "1.0",
-                  "description": "Integration test policy"
-                },
-                "validation_rules": {"host_data": {"exact_match": "test"}}
-              }
+              "metadata": {
+                "name": "CI Persistence Test",
+                "version": "1.0",
+                "description": "Integration test policy",
+                "policy_type": "SEV",
+                "key_id": "ci-persist-test"
+              },
+              "validation_rules": {"host_data": {"exact_match": "test"}}
             }')
           if [ "$HTTP_CODE" -ne 200 ] && [ "$HTTP_CODE" -ne 201 ]; then
             echo "FAIL: Store policy returned HTTP $HTTP_CODE"
@@ -462,12 +460,14 @@ jobs:
             -H "Content-Type: application/json" \
             -H "X-MANAGEMENT-API-KEY: $TAS_MANAGEMENT_API_KEY" \
             -d '{
-              "policy_type": "SEV",
-              "key_id": "ci-auth-test",
-              "policy": {
-                "metadata": {"name": "Auth Test", "version": "1.0", "description": "test"},
-                "validation_rules": {}
-              }
+              "metadata": {
+                "name": "Auth Test",
+                "version": "1.0",
+                "description": "test",
+                "policy_type": "SEV",
+                "key_id": "ci-auth-test"
+              },
+              "validation_rules": {}
             }')
           if [ "$HTTP_CODE" -ne 200 ] && [ "$HTTP_CODE" -ne 201 ]; then
             echo "FAIL: Store returned HTTP $HTTP_CODE"

--- a/README.md
+++ b/README.md
@@ -393,15 +393,16 @@ curl -X POST \
   -H "Content-Type: application/json" \
   -H "X-MANAGEMENT-API-KEY: your-management-key" \
   -d '{
-    "policy_type": "SEV",
-    "key_id": "my-key-1",
-    "policy": {
-      "metadata": {"name": "Test Policy", "version": "1.0"},
-      "signature": {...},
-      "validation_rules": {
-        "measurement": {"exact_match": "abc123"},
-        "debug": false
-      }
+    "metadata": {
+      "name": "Test Policy",
+      "version": "1.0",
+      "policy_type": "...",
+      "key_id": "my-key-1"
+    },
+    "signature": {...},
+    "validation_rules": {
+      "measurement": {"exact_match": "abc123"},
+      "debug": false
     }
   }' \
   http://localhost:5000/management/policy/v0/store

--- a/certs/policy/sev_example_policy.json
+++ b/certs/policy/sev_example_policy.json
@@ -1,6 +1,8 @@
 {
   "metadata": {
     "name": "AMD SEV-SNP Security Policy",
+    "policy_type": "SEV",
+    "key_id": "test-key-1",
     "version": "1.0",
     "description": "Example security policy for validating AMD SEV-SNP attestation reports",
     "created_by": "HPE",

--- a/certs/policy/tdx_example_policy.json
+++ b/certs/policy/tdx_example_policy.json
@@ -1,6 +1,8 @@
 {
   "metadata": {
     "name": "Intel TDX Security Policy",
+    "policy_type": "TDX",
+    "key_id": "test-key-1",
     "version": "1.0",
     "description": "Example security policy for validating Intel TDX quotes",
     "created_by": "HPE",

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -36,6 +36,8 @@ Policies are stored in Redis and referenced during attestation validation to det
     "name": "SEV Example Policy",
     "version": "1.0",
     "description": "Policy description",
+    "policy_type": "SEV",
+    "key_id": "my-secret-id",
     "created_date": "2024-09-09",
     "last_updated": "2024-09-09"
   },
@@ -78,15 +80,17 @@ Policies are stored in Redis and referenced during attestation validation to det
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `policy.metadata` | object | Yes | Policy metadata |
-| `policy.validation_rules` | object | Yes | Attestation validation criteria |
-| `policy.signature` | object | No | Digital signature for integrity |
+| `metadata` | object | Yes | Policy metadata (must include `policy_type` and `key_id`) |
+| `validation_rules` | object | Yes | Attestation validation criteria |
+| `signature` | object | No | Digital signature for integrity |
 
 ### Metadata Fields
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | string | Yes | Human-readable policy name |
+| `policy_type` | string | Yes | TEE type (e.g. `SEV`, `TDX`) |
+| `key_id` | string | Yes | The secret ID this policy is used to release (must match the secret registered in KMS or HSM) |
 | `version` | string | No | Policy version |
 | `description` | string | No | Policy description |
 | `created_by` | string | No | Policy creator |
@@ -220,51 +224,47 @@ python3 demo_signer.py --cert your-policy.json
 ```
 ## Registering Policies
 
-To register a policy with TAS, you must wrap your **signed policy from the previous step** in a registration payload. This payload specifies the policy type and associates it with a secret ID.
+To register a policy with TAS, POST the policy JSON directly to the store endpoint. The `policy_type` and `key_id` are read from the policy's `metadata` section.
 
 Policy registration uses the **management API**, which requires the `X-MANAGEMENT-API-KEY` header (separate from the client `X-API-KEY`).
 
 ### Registration Payload Format
 
-**Important:** The `policy` field contains your complete signed policy from Step 2 above (including metadata, validation_rules, and signature).
+The request body is the complete signed policy from Step 2 above:
 
 ```json
 {
-  "policy_type": "SEV",
-  "key_id": "my-secret-id",
-  "policy": {
-    // This is your complete signed policy from the signing step above
-    "metadata": {
-      "name": "SEV Production Policy",
-      "version": "1.0",
-      "description": "Production policy for SEV attestation",
-      "created_date": "2024-09-09"
+  "metadata": {
+    "name": "SEV Production Policy",
+    "version": "1.0",
+    "description": "Production policy for SEV attestation",
+    "policy_type": "SEV",
+    "key_id": "my-secret-id",
+    "created_date": "2024-09-09"
+  },
+  "validation_rules": {
+    "measurement": {
+      "exact_match": "a1b2c3d4e5f6789..."
     },
-    "validation_rules": {
-      "measurement": {
-        "exact_match": "a1b2c3d4e5f6789..."
-      },
-      "policy": {
-        "debug_allowed": false,
-        "migrate_ma_allowed": false
-      }
-    },
-    "signature": {
-      "algorithm": "SHA384",
-      "padding": "PSS",
-      "value": "base64-encoded-signature..."
+    "policy": {
+      "debug_allowed": false,
+      "migrate_ma_allowed": false
     }
+  },
+  "signature": {
+    "algorithm": "SHA384",
+    "padding": "PSS",
+    "value": "base64-encoded-signature..."
   }
 }
 ```
 
-### Registration Payload Fields
+### Required Metadata Fields for Registration
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `policy_type` | string | Yes | TEE type: either "SEV" or "TDX" |
-| `key_id` | string | Yes | **The secret ID that this policy will be used to release** (must match the secret registered in KMS or HSM) |
-| `policy` | object | Yes | **Your complete signed policy from Step 2** (the entire policy JSON including signature) |
+| `metadata.policy_type` | string | Yes | TEE type: either "SEV" or "TDX" |
+| `metadata.key_id` | string | Yes | **The secret ID that this policy will be used to release** (must match the secret registered in KMS or HSM) |
 
 **How it works:** When a client requests a secret, TAS uses the policy associated with that secret's `key_id` to validate the attestation evidence before releasing the secret. The `key_id` must exist in the key manager that TAS KBM is connected to.
 
@@ -283,14 +283,14 @@ curl -X POST http://localhost:5001/management/policy/v0/store \
   -H "Content-Type: application/json" \
   -H "X-MANAGEMENT-API-KEY: $TAS_MANAGEMENT_API_KEY" \
   -d  '{
-    "policy_type": "SEV",
-    "key_id": "...",
-    "policy": {
-      "metadata": {...},
-      "validation_rules": {...},
-      "signature": {...}
+    "metadata": {
+      "name": "My Policy",
+      "policy_type": "SEV",
+      "key_id": "my-secret-id"
+    },
+    "validation_rules": {...},
+    "signature": {...}
   }'
-  
 
 # Expected response:
 # {"message": "Policy 'policy:policy_type:key_id' stored successfully"}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -116,6 +116,15 @@
             "type": "string",
             "description": "Policy name"
           },
+          "policy_type": {
+            "type": "string",
+            "description": "TEE type (e.g. SEV, TDX)",
+            "example": "SEV"
+          },
+          "key_id": {
+            "type": "string",
+            "description": "Identifier of the key to retrieve after successful attestation against policy"
+          },
           "version": {
             "type": "string",
             "description": "Policy version"
@@ -139,7 +148,9 @@
         },
         "required": [
           "name",
-          "version"
+          "version",
+          "policy_type",
+          "key_id"
         ]
       },
       "PolicyValidationRules": {
@@ -219,28 +230,6 @@
         "required": [
           "metadata",
           "validation_rules"
-        ]
-      },
-      "PolicyStoreRequest": {
-        "type": "object",
-        "properties": {
-          "policy_type": {
-            "type": "string",
-            "description": "Type of policy",
-            "example": "SEV"
-          },
-          "key_id": {
-            "type": "string",
-            "description": "Identifier of the key to retrieve after successful attestation against policy"
-          },
-          "policy": {
-            "$ref": "#/components/schemas/PolicyData"
-          }
-        },
-        "required": [
-          "policy_type",
-          "key_id",
-          "policy"
         ]
       },
       "VersionResponse": {
@@ -437,7 +426,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PolicyStoreRequest"
+                "$ref": "#/components/schemas/PolicyData"
               }
             }
           }
@@ -889,7 +878,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PolicyStoreRequest"
+                "$ref": "#/components/schemas/PolicyData"
               }
             }
           }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -84,6 +84,14 @@ components:
         name:
           type: string
           description: Policy name
+        policy_type:
+          type: string
+          description: TEE type (e.g. SEV, TDX)
+          example: SEV
+        key_id:
+          type: string
+          description: Identifier of the key to retrieve after successful attestation
+            against policy
         version:
           type: string
           description: Policy version
@@ -102,6 +110,8 @@ components:
       required:
       - name
       - version
+      - policy_type
+      - key_id
     PolicyValidationRules:
       type: object
       properties:
@@ -157,22 +167,6 @@ components:
       required:
       - metadata
       - validation_rules
-    PolicyStoreRequest:
-      type: object
-      properties:
-        policy_type:
-          type: string
-          description: Type of policy
-          example: SEV
-        key_id:
-          type: string
-          description: Identifier of the key to retrieve after successful attestation against policy
-        policy:
-          $ref: '#/components/schemas/PolicyData'
-      required:
-      - policy_type
-      - key_id
-      - policy
     VersionResponse:
       type: object
       properties:
@@ -299,7 +293,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PolicyStoreRequest'
+              $ref: '#/components/schemas/PolicyData'
       responses:
         '201':
           description: Policy stored successfully
@@ -543,7 +537,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PolicyStoreRequest'
+              $ref: '#/components/schemas/PolicyData'
       responses:
         '201':
           description: Policy stored successfully

--- a/tas/management_routes.py
+++ b/tas/management_routes.py
@@ -40,47 +40,10 @@ def store_policy():
     if auth_response:
         return auth_response
 
-    data = request.get_json()
-    if not data:
+    policy = request.get_json()
+    if not policy:
         logger.error("Policy store request missing JSON body")
         return jsonify({"error": "Request body is required"}), 400
-
-    policy_type = data.get("policy_type")
-    if not policy_type:
-        logger.error("Policy store request missing policy_type")
-        return jsonify({"error": "Policy type is required (e.g. SEV, TDX)"}), 400
-
-    if not POLICY_KEY_COMPONENT_RE.match(str(policy_type)):
-        logger.error(f"Invalid policy_type: {policy_type}")
-        return (
-            jsonify(
-                {
-                    "error": "Invalid policy_type. Use only alphanumeric characters, hyphens, underscores, and dots"
-                }
-            ),
-            400,
-        )
-
-    key_id = data.get("key_id")
-    if not key_id:
-        logger.error("Policy store request missing key_id")
-        return jsonify({"error": "Key ID is required"}), 400
-
-    if not POLICY_KEY_COMPONENT_RE.match(str(key_id)):
-        logger.error(f"Invalid key_id: {key_id}")
-        return (
-            jsonify(
-                {
-                    "error": "Invalid key_id. Use only alphanumeric characters, hyphens, underscores, and dots"
-                }
-            ),
-            400,
-        )
-
-    policy = data.get("policy")
-    if not policy:
-        logger.error("Policy store request missing policy data")
-        return jsonify({"error": "Policy data is required"}), 400
 
     if not isinstance(policy, dict):
         logger.error("Policy data is not a valid JSON object")
@@ -93,6 +56,43 @@ def store_policy():
     if "validation_rules" not in policy:
         logger.error("Policy missing required 'validation_rules' section")
         return jsonify({"error": "Policy must contain 'validation_rules' section"}), 400
+
+    metadata = policy["metadata"]
+
+    policy_type = metadata.get("policy_type")
+    if not policy_type:
+        logger.error("Policy metadata missing policy_type")
+        return (
+            jsonify({"error": "Policy type is required in metadata (e.g. SEV, TDX)"}),
+            400,
+        )
+
+    if not POLICY_KEY_COMPONENT_RE.match(str(policy_type)):
+        logger.error(f"Invalid policy_type: {policy_type}")
+        return (
+            jsonify(
+                {
+                    "error": "Invalid policy_type. Use only alphanumeric characters, hyphens, underscores, and dots"
+                }
+            ),
+            400,
+        )
+
+    key_id = metadata.get("key_id")
+    if not key_id:
+        logger.error("Policy metadata missing key_id")
+        return jsonify({"error": "Key ID is required in metadata"}), 400
+
+    if not POLICY_KEY_COMPONENT_RE.match(str(key_id)):
+        logger.error(f"Invalid key_id: {key_id}")
+        return (
+            jsonify(
+                {
+                    "error": "Invalid key_id. Use only alphanumeric characters, hyphens, underscores, and dots"
+                }
+            ),
+            400,
+        )
 
     is_signed = "signature" in policy
     warning_message = None

--- a/tests/test_management_routes.py
+++ b/tests/test_management_routes.py
@@ -21,18 +21,16 @@ CLIENT_API_KEY = "a" * 64
 MGMT_API_KEY = "b" * 64
 
 VALID_POLICY_PAYLOAD = {
-    "policy_type": "SEV",
-    "key_id": "test-key-1",
-    "policy": {
-        "metadata": {
-            "name": "Test Policy",
-            "version": "1.0",
-            "description": "A test policy",
-        },
-        "validation_rules": {
-            "host_data": {"exact_match": "abc123"},
-            "policy": {"debug_allowed": False},
-        },
+    "metadata": {
+        "name": "Test Policy",
+        "version": "1.0",
+        "description": "A test policy",
+        "policy_type": "SEV",
+        "key_id": "test-key-1",
+    },
+    "validation_rules": {
+        "host_data": {"exact_match": "abc123"},
+        "policy": {"debug_allowed": False},
     },
 }
 
@@ -141,7 +139,8 @@ class TestManagementStorePolicy:
         assert resp.status_code == 400
 
     def test_store_policy_missing_policy_type(self, client, mgmt_headers):
-        payload = {**VALID_POLICY_PAYLOAD, "policy_type": None}
+        payload = json.loads(json.dumps(VALID_POLICY_PAYLOAD))
+        del payload["metadata"]["policy_type"]
         resp = client.post(
             "/management/policy/v0/store",
             headers=mgmt_headers,
@@ -150,7 +149,8 @@ class TestManagementStorePolicy:
         assert resp.status_code == 400
 
     def test_store_policy_invalid_policy_type(self, client, mgmt_headers):
-        payload = {**VALID_POLICY_PAYLOAD, "policy_type": "bad chars!@#"}
+        payload = json.loads(json.dumps(VALID_POLICY_PAYLOAD))
+        payload["metadata"]["policy_type"] = "bad chars!@#"
         resp = client.post(
             "/management/policy/v0/store",
             headers=mgmt_headers,
@@ -164,7 +164,7 @@ class TestManagementGetPolicy:
         # Store a policy first
         app.extensions["redis"].set(
             "policy:SEV:test-key-1",
-            json.dumps(VALID_POLICY_PAYLOAD["policy"]),
+            json.dumps(VALID_POLICY_PAYLOAD),
         )
         resp = client.get(
             "/management/policy/v0/get/policy:SEV:test-key-1",
@@ -200,7 +200,7 @@ class TestManagementListPolicies:
     def test_list_policies_with_data(self, client, mgmt_headers, app):
         app.extensions["redis"].set(
             "policy:SEV:key1",
-            json.dumps(VALID_POLICY_PAYLOAD["policy"]),
+            json.dumps(VALID_POLICY_PAYLOAD),
         )
         resp = client.get("/management/policy/v0/list", headers=mgmt_headers)
         assert resp.status_code == 200
@@ -212,7 +212,7 @@ class TestManagementDeletePolicy:
     def test_delete_policy_success(self, client, mgmt_headers, app):
         app.extensions["redis"].set(
             "policy:SEV:to-delete",
-            json.dumps(VALID_POLICY_PAYLOAD["policy"]),
+            json.dumps(VALID_POLICY_PAYLOAD),
         )
         resp = client.delete(
             "/management/policy/v0/delete/policy:SEV:to-delete",
@@ -270,7 +270,7 @@ class TestDeprecatedRoutes:
     def test_deprecated_get_has_deprecation_header(self, client, mgmt_headers, app):
         app.extensions["redis"].set(
             "policy:SEV:dep-test",
-            json.dumps(VALID_POLICY_PAYLOAD["policy"]),
+            json.dumps(VALID_POLICY_PAYLOAD),
         )
         resp = client.get(
             "/policy/v0/get/policy:SEV:dep-test",
@@ -284,7 +284,7 @@ class TestDeprecatedRoutes:
     def test_deprecated_delete_has_deprecation_header(self, client, mgmt_headers, app):
         app.extensions["redis"].set(
             "policy:SEV:dep-del",
-            json.dumps(VALID_POLICY_PAYLOAD["policy"]),
+            json.dumps(VALID_POLICY_PAYLOAD),
         )
         resp = client.delete(
             "/policy/v0/delete/policy:SEV:dep-del",


### PR DESCRIPTION
The policy_type and key_id fields are now in the metadata structure within policies meaning they can be signed as well. This also means that the JSON payload for creating policies is just policy rather than a policy wrapped with extra fields.

Docs and openapi specs updated accordingly.