### PR TITLE
Add canonicalization method for consistancy

### DIFF
--- a/tas/policy_helper.py
+++ b/tas/policy_helper.py
@@ -77,33 +77,21 @@ def verify_policy_signature(policy_data, public_keys):
                 return False
 
             logger.debug(f"Signature covers specified fields: {signed_data_spec}")
-            if len(signed_data_spec) == 1:
-                # Single field: canonicalize the field value directly (backward compatible)
-                field = signed_data_spec[0]
+            for field in signed_data_spec:
                 if field not in policy_data:
                     logger.error(
                         f"signed_data field '{field}' not found in policy data"
                     )
                     return False
-                data_to_verify = policy_data[field]
-            else:
-                # Multiple fields: build a dict of the specified fields
-                data_to_verify = {}
-                for field in sorted(signed_data_spec):
-                    if field not in policy_data:
-                        logger.error(
-                            f"signed_data field '{field}' not found in policy data"
-                        )
-                        return False
-                    data_to_verify[field] = policy_data[field]
+
+            data_to_verify = {f: policy_data[f] for f in signed_data_spec}
+            signed_json = canonicalize_policy(data_to_verify)
         else:
             # Default: signature covers all top-level fields except "signature"
             logger.debug(
                 "No signed_data specified, signature covers all fields except 'signature'"
             )
-            data_to_verify = {k: v for k, v in policy_data.items() if k != "signature"}
-
-        signed_json = rfc8785.dumps(data_to_verify)
+            signed_json = canonicalize_policy(policy_data)
         logger.debug(
             f"Prepared data for verification, length: {len(signed_json)} bytes"
         )
@@ -166,6 +154,11 @@ POLICY_KEY_COMPONENT_RE = re.compile(r"^[A-Za-z0-9_.-]+\Z")
 
 # Regex for validating a full policy key: policy:{type}:{key_id}
 POLICY_KEY_RE = re.compile(r"^policy:[A-Za-z0-9_-]+:[A-Za-z0-9_.-]+\Z")
+
+
+def canonicalize_policy(policy_data):
+    """Return the RFC 8785 (JCS) canonical bytes of a policy, excluding the signature field."""
+    return rfc8785.dumps({k: v for k, v in policy_data.items() if k != "signature"})
 
 
 def validate_policy_key(policy_key):

--- a/tests/test_policy_helper.py
+++ b/tests/test_policy_helper.py
@@ -16,7 +16,6 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
-import rfc8785
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
@@ -82,19 +81,18 @@ class TestVerifyPolicySignature:
 
     def create_valid_signature(self, policy_data, private_key, padding_scheme="PSS"):
         """Helper method to create a valid signature for test data."""
+        from tas.policy_helper import canonicalize_policy
+
         signed_data_spec = policy_data.get("signature", {}).get("signed_data")
 
         if signed_data_spec is not None:
             if isinstance(signed_data_spec, str):
                 signed_data_spec = [signed_data_spec]
-            if len(signed_data_spec) == 1:
-                data_to_sign = policy_data[signed_data_spec[0]]
-            else:
-                data_to_sign = {k: policy_data[k] for k in sorted(signed_data_spec)}
+            data_to_sign = {k: policy_data[k] for k in signed_data_spec}
         else:
-            data_to_sign = {k: v for k, v in policy_data.items() if k != "signature"}
+            data_to_sign = policy_data
 
-        data_json = rfc8785.dumps(data_to_sign)
+        data_json = canonicalize_policy(data_to_sign)
 
         # Create signature
         if padding_scheme == "PSS":


### PR DESCRIPTION
Added a method in policy_helper to canonicalize policies for signing for ease of use and to ensure consistancy.