### PR TITLE
Reject duplicate policies rather than overwrite

### DIFF
--- a/tas/management_routes.py
+++ b/tas/management_routes.py
@@ -127,8 +127,12 @@ def store_policy():
     try:
         redis_client = _get_redis()
         policy_key = f"policy:{policy_type}:{key_id}"
-        policy_json = json.dumps(policy)
 
+        if redis_client.get(policy_key) is not None:
+            logger.error(f"Policy '{policy_key}' already exists in Redis")
+            return jsonify({"error": f"Policy '{policy_key}' already exists"}), 409
+
+        policy_json = json.dumps(policy)
         redis_client.set(policy_key, policy_json)
 
         logger.info(f"Stored policy '{policy_key}' in Redis")


### PR DESCRIPTION
Store policy management route will now fail if a policy with a matching key is attempted to be added, rather than overwriting the existing policy. The delete action needs to be performed first before adding the policy.