### PR TITLE
Add Thales CipherTrust Manager (CTM) KBM plugin integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ TAS supports pluggable Key Broker Modules (KBM) for different backend key manage
 | Plugin | Description | Use Case |
 |--------|-------------|----------|
 | `tas_kbm_kmip_json` | KMIP JSON protocol backend | Production with KMIP servers (Cosmain KMS, etc.) |
+| `tas_kbm_thales_ctm` | Thales CipherTrust Manager backend | Production with Thales CTM for key wrapping and export |
 | `tas_kbm_mock` | Software-based mock | Development and testing |
 
 ### Plugin Interface

--- a/certs/.gitignore
+++ b/certs/.gitignore
@@ -4,3 +4,4 @@
 *
 # Except this file
 !.gitignore
+!thales_ctm

--- a/certs/thales_ctm/.gitignore
+++ b/certs/thales_ctm/.gitignore
@@ -1,0 +1,7 @@
+# Place Thales CTM certificates in this directory.
+# See README.md for details on obtaining and naming them.
+#
+# Ignore everything in this directory except this file and the README
+*
+!.gitignore
+!README.md

--- a/certs/thales_ctm/README.md
+++ b/certs/thales_ctm/README.md
@@ -1,0 +1,97 @@
+# Thales CipherTrust Manager (CTM) Certificates
+
+This directory holds the TLS certificates used by the Thales CTM plugin to authenticate to a CipherTrust Manager instance. All certificate files are excluded from version control via `.gitignore` and must be placed here manually before starting the service.
+
+## Expected files
+
+| File | Description |
+|---|---|
+| `ca_cert.pem` | CA certificate that signed the CTM server certificate (used to verify the server's TLS identity) |
+| `client_cert.pem` | Client public certificate used for certificate-based login |
+| `client_key.pem` | Client private key paired with `client_cert.pem` |
+
+These paths are referenced in `config/thales_ctm/thales_ctm.yaml`:
+
+```yaml
+ca_certfile: "certs/thales_ctm/ca_cert.pem"
+auth_certfile: "certs/thales_ctm/client_cert.pem"
+auth_keyfile: "certs/thales_ctm/client_key.pem"
+```
+
+> **Note:** Certificate-based login is only active when `certificate_login: true` is set in `thales_ctm.yaml`. When it is `false`, `client_cert.pem` and `client_key.pem` are not used, but `ca_cert.pem` is still required unless `verify_ssl: false`.
+
+---
+
+## Obtaining the CA certificate (`ca_cert.pem`)
+
+The CA certificate comes from your CTM instance's local CA.
+
+1. Log in to Thales CTM with an Admin account.
+2. In the left-hand navigation, go to **CA → Local**.
+3. If no local CA exists, create one.
+4. Download the existing CA using the **⋯** menu on the right-hand side next to the certificate entry.
+5. Save the downloaded PEM file as `certs/thales_ctm/ca_cert.pem`.
+
+Reference: <https://thalesdocs.com/ctp/cm/2.8/admin/cm_admin/certificate-based-auth/index.html>
+
+---
+
+## Obtaining the client certificate and key (`client_cert.pem` / `client_key.pem`)
+
+Certificate-based authentication requires that the CTM user account has a Login Certificate configured.
+
+### Step 1 — Generate a key pair and CSR
+
+```bash
+# Generate a 2048-bit RSA private key
+openssl genrsa -out certs/thales_ctm/client_key.pem 2048
+
+# Create a certificate signing request (CSR)
+openssl req -new \
+  -key certs/thales_ctm/client_key.pem \
+  -out /tmp/client.csr \
+  -subj "/CN=<your-ctm-username>"
+```
+
+### Step 2 — Sign the CSR with the CTM local CA
+
+Submit `/tmp/client.csr` to your CTM instance to be signed by the local CA:
+
+1. Log in to Thales CTM as an Admin.
+2. Go to **CA → Local** and select your CA.
+3. Choose **Issue Certificate** (or equivalent option).
+4. Upload the CSR and download the signed certificate.
+5. Save the signed certificate as `certs/thales_ctm/client_cert.pem`.
+
+> Alternatively, your Thales CTM administrator can generate the key pair and certificate directly in CTM and export them for you.
+
+### Step 3 — Attach the certificate to the CTM user account
+
+1. In Thales CTM, navigate to **Access Management → Users**.
+2. Select the user account that TAS will authenticate as.
+3. Under **Login Certificates**, add the contents of `client_cert.pem`.
+
+Reference: <https://thalesdocs.com/ctp/cm/2.8/admin/cm_admin/certificate-based-auth/index.html>
+
+---
+
+## Enabling certificate-based login
+
+In `config/thales_ctm/thales_ctm.yaml`, set:
+
+```yaml
+certificate_login: true
+verify_ssl: true
+```
+
+When `certificate_login` is `false`, the plugin uses username/password authentication (via `THALES_CTM_USERNAME` / `THALES_CTM_PASSWORD` environment variables) and the client cert/key files are ignored.
+
+---
+
+## File permissions
+
+Restrict access to the private key to prevent unauthorised reads:
+
+```bash
+chmod 600 certs/thales_ctm/client_key.pem
+```

--- a/config/tas_config.yaml
+++ b/config/tas_config.yaml
@@ -30,7 +30,7 @@ SERVER_PORT: 5000
 
 # KBM plugin discovery and config
 #TAS_PLUGIN_PREFIX: "tas_kbm"
-#TAS_KBM_CONFIG_FILE: "./config/pykmip/pykmip.conf"
+#TAS_KBM_CONFIG_FILE: "./config/thales_ctm/thales_ctm.yaml"
 
 # Verification Policy settings
 TAS_POLICY_TRUST: "./certs/policy"

--- a/config/thales_ctm/thales_ctm.yaml
+++ b/config/thales_ctm/thales_ctm.yaml
@@ -1,0 +1,12 @@
+debug: false
+host: "${THALES_CTM_HOST}"
+username: "${THALES_CTM_USERNAME}"
+password: "${THALES_CTM_PASSWORD}"
+domain: "root"
+verify_ssl: true
+certificate_login: false
+ca_certfile: "certs/thales_ctm/ca_cert.pem"
+auth_certfile: "certs/thales_ctm/client_cert.pem"
+auth_keyfile: "certs/thales_ctm/client_key.pem"
+key_wrap_algorithm: "AES-KWP"
+requests_timeout: 15 # Timeout in seconds for HTTP requests to Thales CTM API (used in authentication and key operations)

--- a/plugins/tas_kbm_thales_ctm.py
+++ b/plugins/tas_kbm_thales_ctm.py
@@ -1,0 +1,625 @@
+#
+# TEE Attestation Service - Thales CipherTrust Manager (CTM) Plugin Integration
+#
+# Copyright 2026 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# This file is part of the TEE Attestation Service.
+#
+# This plugin provides integration with Thales CipherTrust Manager (CTM)
+# for key management and secret wrapping operations.
+# The plugin implements the necessary methods to interact with CTM's API.
+
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import re
+import threading
+import time
+from typing import Any, Dict, Optional
+from urllib.parse import urljoin
+
+import requests
+import urllib3
+
+try:
+    import yaml  # PyYAML (listed in requirements)
+except Exception:
+    yaml = None
+
+from cryptography.hazmat.primitives.serialization import (
+    load_der_public_key,
+    load_pem_public_key,
+)
+
+from tas.tas_logging import get_logger
+
+# Setup logging for the Thales CTM KBM plugin
+logger = get_logger("tas.plugins.tas_kbm_thales_ctm")
+
+
+def _load_rsa_public_key(raw: bytes):
+    """Load RSA public key from PEM or DER format"""
+    try:
+        pub_key = load_pem_public_key(raw)
+        logger.debug("Successfully loaded PEM public key")
+        return pub_key
+    except Exception:
+        pass
+    try:
+        pub_key = load_der_public_key(raw)
+        logger.debug("Successfully loaded DER public key")
+        key_size = pub_key.key_size
+        logger.info(f"Loaded RSA public key: {key_size} bits")
+        return pub_key
+    except Exception as e:
+        raise ValueError("Invalid RSA public key format") from e
+
+
+def _load_config_file(config_file: Optional[str]) -> Dict[str, Any]:
+    """Load configuration from YAML or JSON file with environment variable substitution"""
+    if not config_file:
+        logger.debug("No config file specified")
+        return {}
+    path = os.path.abspath(config_file)
+    if not os.path.isfile(path):
+        logger.warning(f"Config file not found: {path}")
+        return {}
+
+    logger.info(f"Loading Thales CTM KBM config from: {path}")
+
+    # Read the raw file content first
+    with open(path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    # Perform environment variable substitution
+    def env_replacer(match):
+        env_var = match.group(1)
+        env_value = os.getenv(env_var)
+        if env_value is None:
+            logger.warning(
+                f"Environment variable {env_var} not found, keeping placeholder"
+            )
+            return match.group(0)  # Keep original ${VAR} if not found
+        logger.debug(f"Substituted environment variable: {env_var}")
+        return env_value
+
+    # Replace ${VAR_NAME} with environment variable values
+    content = re.sub(r"\$\{([^}]+)\}", env_replacer, content)
+
+    # Try YAML first if extension suggests YAML and PyYAML is available
+    _, ext = os.path.splitext(path.lower())
+    if ext in (".yaml", ".yml") and yaml:
+        try:
+            data = yaml.safe_load(content) or {}
+            if isinstance(data, dict):
+                logger.debug(
+                    f"Successfully loaded YAML config with keys: {list(data.keys())}"
+                )
+                return data
+        except Exception as e:
+            logger.warning(f"Failed to parse config as YAML: {e}")
+    # Fallback JSON
+    try:
+        data = json.loads(content) or {}
+        logger.debug(f"Successfully loaded JSON config with keys: {list(data.keys())}")
+        return data
+    except Exception as e:
+        logger.warning(f"Failed to parse config as JSON: {e}")
+        return {}
+
+
+class _CTMKBMClient:
+    """Thales CTM Key Management Backend client"""
+
+    def __init__(
+        self,
+        host: str,
+        verify_ssl: bool = True,
+        ca_cert: Optional[str] = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        cert_file: Optional[str] = None,
+        key_file: Optional[str] = None,
+        certificate_login: bool = False,
+        domain: str = "root",
+        key_wrap_algorithm: str = "AES-KWP",
+        requests_timeout: Optional[int] = None,
+    ):
+        self.host = host
+        self.username = username
+        self.password = password
+        self.domain = domain
+        self.verify_ssl = verify_ssl
+        self.ca_cert = ca_cert
+        self.cert_file = cert_file
+        self.key_file = key_file
+        self.certificate_login = certificate_login
+        self.bearer_token = None
+        self.key_wrap_algorithm = key_wrap_algorithm
+        self.requests_timeout = requests_timeout
+        self._lock = threading.RLock()
+
+        # Map canonical algorithm names to the strings Thales CTM accepts
+        self._ctm_algorithm_map = {
+            "AES-KWP": "AES/AESKEYWRAPPADDING",
+        }
+
+        # Validate authentication configuration
+        if certificate_login:
+            if not cert_file or not key_file:
+                raise ValueError(
+                    "Certificate and key files required for certificate authentication"
+                )
+            if not os.path.isfile(cert_file):
+                raise ValueError(f"Certificate file not found: {cert_file}")
+            if not os.path.isfile(key_file):
+                raise ValueError(f"Key file not found: {key_file}")
+        else:
+            if not username or not password:
+                raise ValueError(
+                    "Username and password required for password authentication"
+                )
+
+        # Validate SSL configuration
+        if verify_ssl and ca_cert:
+            if not os.path.isfile(ca_cert):
+                raise ValueError(f"CA certificate file not found: {ca_cert}")
+
+        auth_type = "certificate" if certificate_login else "password"
+        logger.debug(
+            f"Initialized Thales CTM KBM client for host: {host} with {auth_type} authentication"
+        )
+
+    def authenticate(self):
+        """Authenticate to Thales CTM and get bearer token"""
+        auth_type = "certificate" if self.certificate_login else "password"
+        logger.info(
+            f"Authenticating to Thales CTM at {self.host} using {auth_type} authentication"
+        )
+
+        # Build auth URL
+        auth_url = f"https://{self.host}/api/v1/auth/tokens"
+
+        # Prepare SSL verification
+        verify_param = False
+        if self.verify_ssl:
+            verify_param = self.ca_cert if self.ca_cert else True
+
+        # Prepare request parameters
+        request_kwargs = {"verify": verify_param}
+
+        if self.certificate_login:
+            # Certificate-based authentication using user_certificate grant type
+            auth_data = {"grant_type": "user_certificate", "domain": self.domain}
+            request_kwargs["cert"] = (self.cert_file, self.key_file)
+            logger.debug(
+                "Using certificate authentication with user_certificate grant type"
+            )
+        else:
+            # Username/password authentication
+            auth_data = {
+                "username": self.username,
+                "password": self.password,
+                "domain": self.domain,
+            }
+            logger.debug("Using username/password authentication")
+
+        # Make auth request
+        if self.requests_timeout:
+            request_kwargs["timeout"] = self.requests_timeout
+        response = requests.post(auth_url, json=auth_data, **request_kwargs)
+
+        if response.status_code == 200:
+            token_data = response.json()
+            self.bearer_token = token_data.get("jwt")
+            client_verify = response.headers.get("Client-Verify", "N/A")
+            logger.info(
+                f"Successfully authenticated to Thales CTM (Client-Verify: {client_verify})"
+            )
+            return self.bearer_token
+        else:
+            logger.error(
+                f"Authentication failed: {response.status_code} - {response.text}"
+            )
+            raise Exception(f"Thales CTM auth failed: {response.status_code}")
+
+    def _ensure_authenticated(self):
+        """Ensure we have a valid bearer token"""
+        if not self.bearer_token:
+            self.authenticate()
+
+    def _make_request(self, method: str, endpoint: str, **kwargs):
+        """Make authenticated request to Thales CTM API"""
+        self._ensure_authenticated()
+
+        base_url = f"https://{self.host}/api/v1/"
+        url = urljoin(base_url, endpoint)
+
+        headers = kwargs.setdefault("headers", {})
+        headers["Authorization"] = f"Bearer {self.bearer_token}"
+        headers.setdefault("Content-Type", "application/json")
+
+        # Set SSL verification based on configuration
+        if self.verify_ssl:
+            kwargs.setdefault("verify", self.ca_cert if self.ca_cert else True)
+        else:
+            kwargs.setdefault("verify", False)
+
+        # Set request timeout if configured
+        if self.requests_timeout:
+            kwargs.setdefault("timeout", self.requests_timeout)
+
+        return requests.request(method, url, **kwargs)
+
+    def get_secret(self, key_id: str, wrapping_key: bytes) -> Dict[str, str]:
+        """
+        Get and wrap a secret from Thales CTM using RSA public key wrapping.
+
+        Args:
+            key_id: ID of the secret/key to retrieve from CTM
+            wrapping_key: RSA public key (can be raw bytes, PEM, DER, or base64 encoded)
+
+        Returns:
+            Dictionary with wrapped_key, blob, iv, and tag in base64 format
+        """
+        logger.info(f"Thales CTM KBM get_secret request for key_id: {key_id}")
+
+        with self._lock:
+            if isinstance(wrapping_key, bytes):
+                wrapping_key_b64 = base64.b64encode(wrapping_key).decode("ascii")
+                logger.debug("\n" + "=" * 70)
+                logger.debug(f"Received public key (base64): {wrapping_key_b64}")
+                logger.debug("\n" + "=" * 70)
+
+            # Decode base64 if necessary
+            if isinstance(wrapping_key, bytes):
+                # Check if it's base64 encoded by trying to decode
+                try:
+                    decoded = base64.b64decode(wrapping_key)
+                    # If successful and it looks like a valid key, use the decoded version
+                    if b"-----BEGIN" in decoded or len(decoded) > 100:
+                        logger.debug(
+                            "Detected base64 encoded public key, decoded successfully"
+                        )
+                        wrapping_key = decoded
+                except Exception:
+                    # Not base64 or decoding failed, use as-is
+                    logger.debug("Using public key as provided (not base64 encoded)")
+
+            # Load and validate the RSA public key
+            pub = _load_rsa_public_key(wrapping_key)
+            logger.info(f"Validated RSA public key: {pub.key_size} bits")
+
+            temp_wrapping_key_id = None
+            try:
+                # Step 1: Generate temporary AES-256 wrapping key in CTM
+                logger.info("Step 1: Generating temporary AES-256 wrapping key in CTM")
+                temp_wrapping_key_id = self._generate_aes_key()
+
+                # Step 2: Wrap the secret with the temporary wrapping key using AES Key Wrap
+                logger.info(
+                    f"Step 2: Wrapping secret {key_id} with temporary wrapping key"
+                )
+                wrapped_secret_result = self._wrap_key(key_id, temp_wrapping_key_id)
+                wrapped_secret_material = wrapped_secret_result.get("material", "")
+
+                if not wrapped_secret_material:
+                    raise Exception("No wrapped secret material returned from CTM")
+
+                logger.info(
+                    f"Secret wrapped successfully, material length: {len(wrapped_secret_material)} chars"
+                )
+
+                # Step 3: Wrap the temporary wrapping key with the RSA public key
+                logger.info(
+                    "Step 3: Wrapping temporary wrapping key with RSA public key"
+                )
+                wrapped_wrapping_key_result = self._wrap_key_with_public_key(
+                    temp_wrapping_key_id, wrapping_key
+                )
+                wrapped_wrapping_key_material = wrapped_wrapping_key_result.get(
+                    "material", ""
+                )
+
+                if not wrapped_wrapping_key_material:
+                    raise Exception(
+                        "No wrapped wrapping key material returned from CTM"
+                    )
+
+                logger.info(
+                    f"Wrapping key wrapped successfully, material length: {len(wrapped_wrapping_key_material)} chars"
+                )
+
+                # Step 4: Return in the expected format
+                # Note: AES Key Wrap doesn't use IV or tag, but we include empty strings for compatibility
+
+                # To conform to all other data being Base64 encoded, the algorithm is encoded too.
+                algorithm_b64 = base64.b64encode(
+                    self.key_wrap_algorithm.encode("utf-8")
+                ).decode("ascii")
+
+                result = {
+                    "wrapped_key": wrapped_wrapping_key_material,  # RSA-wrapped AES wrapping key
+                    "blob": wrapped_secret_material,  # AES Key Wrap encrypted secret
+                    "iv": "",  # Not used in AES Key Wrap
+                    "tag": "",  # Not used in AES Key Wrap
+                    "algorithm": algorithm_b64,  # Indicate the wrapping algorithm used
+                }
+
+                # Log the payload
+                logger.debug("\n" + "=" * 70)
+                logger.debug("PAYLOAD (Result):")
+                logger.debug(f"wrapped_key: {result['wrapped_key']}")
+                logger.debug(f"blob: {result['blob']}")
+                logger.debug(f"iv: {result['iv']}")
+                logger.debug(f"tag: {result['tag']}")
+                logger.debug("=" * 70 + "\n")
+
+                logger.info(f"Successfully wrapped secret for key_id: {key_id}")
+                return result
+
+            finally:
+                # Step 5: Cleanup - delete the temporary wrapping key
+                if temp_wrapping_key_id:
+                    try:
+                        logger.info("Step 4: Cleaning up temporary wrapping key")
+                        self._delete_key(temp_wrapping_key_id)
+                        logger.info("Temporary wrapping key deleted successfully")
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to delete temporary wrapping key {temp_wrapping_key_id}: {e}"
+                        )
+                # Clear bearer token to force fresh authentication on next request
+                # Prevents token expiration issues when TAS server runs for > 300 seconds
+                self.bearer_token = None
+                logger.debug("Bearer token cleared after kbm_get_secret completion")
+
+    def _generate_aes_key(self, key_name: str = None) -> str:
+        """Generate a random AES-256 key in Thales CTM and return the key ID"""
+        if not key_name:
+            timestamp = int(time.time())
+            key_name = f"temp-AES-Key-{timestamp}"
+
+        logger.info(f"Generating AES-256 key in CTM with name: {key_name}")
+
+        key_data = {
+            "name": key_name,
+            "algorithm": "aes",
+            "size": 256,
+            "usageMask": 81,  # Wrap Key (16) + Export (64) + Encrypt (1) = 81
+            "format": "raw",
+        }
+
+        response = self._make_request("POST", "vault/keys2/", json=key_data)
+
+        if response.status_code == 201:
+            result = response.json()
+            key_id = result.get("id")
+            if not key_id:
+                raise Exception("CTM did not return a key ID")
+            logger.info(f"Successfully created AES-256 key: {key_id}")
+            return key_id
+        else:
+            logger.error(
+                f"Key generation failed: {response.status_code} - {response.text}"
+            )
+            raise Exception(f"Thales CTM key generation failed: {response.status_code}")
+
+    def _delete_key(self, key_id: str) -> bool:
+        """Delete a key from Thales CTM"""
+        logger.info(f"Deleting key from CTM: {key_id}")
+
+        response = self._make_request("DELETE", f"vault/keys2/{key_id}")
+
+        if response.status_code in (200, 204):
+            logger.info(f"Successfully deleted key: {key_id}")
+            return True
+        else:
+            logger.error(
+                f"Key deletion failed: {response.status_code} - {response.text}"
+            )
+            raise Exception(f"Thales CTM key deletion failed: {response.status_code}")
+
+    def _wrap_key(self, secret_key_id: str, wrapping_key_id: str) -> Dict[str, Any]:
+        """
+        Wrap/export a secret key using a wrapping key with AES Key Wrap with Padding (RFC 5649)
+
+        Args:
+            secret_key_id: ID of the pre-existing secret to wrap
+            wrapping_key_id: ID of the AES-256 wrapping key
+
+        Returns:
+            Dictionary containing the wrapped material and metadata from CTM
+        """
+
+        logger.info(
+            f"Wrapping secret {secret_key_id} with wrapping key {wrapping_key_id}"
+        )
+
+        ctm_algo = self._ctm_algorithm_map.get(
+            self.key_wrap_algorithm, self.key_wrap_algorithm
+        )
+        logger.debug(
+            f"Translating key wrap algorithm '{self.key_wrap_algorithm}' -> '{ctm_algo}' for CTM API"
+        )
+
+        export_data = {
+            "format": "raw",
+            "wrappingMethod": "encrypt",
+            "wrapKeyName": wrapping_key_id,
+            "wrappingEncryptionAlgo": ctm_algo,
+        }
+
+        response = self._make_request(
+            "POST", f"vault/keys2/{secret_key_id}/export", json=export_data
+        )
+
+        if response.status_code == 200:
+            result = response.json()
+            material = result.get("material", "")
+            logger.info(
+                f"Successfully wrapped secret with AES Key Wrap (RFC 5649), material length: {len(material)} chars"
+            )
+            return result
+        else:
+            logger.error(
+                f"Key wrapping failed: {response.status_code} - {response.text}"
+            )
+            raise Exception(f"Thales CTM key wrapping failed: {response.status_code}")
+
+    def _wrap_key_with_public_key(
+        self, wrapping_key_id: str, public_key_pem: bytes
+    ) -> Dict[str, Any]:
+        """
+        Wrap/export the wrapping key using an RSA public key
+
+        Args:
+            wrapping_key_id: ID of the AES-256 wrapping key to wrap
+            public_key_pem: RSA public key in PEM format
+
+        Returns:
+            Dictionary containing the wrapped wrapping key material from CTM
+        """
+        logger.info(f"Wrapping AES key {wrapping_key_id} with RSA public key")
+
+        # Convert bytes to string if needed
+        if isinstance(public_key_pem, bytes):
+            try:
+                public_key_pem = public_key_pem.decode("utf-8")
+            except UnicodeDecodeError:
+                # If UTF-8 fails, try to load as DER and convert to PEM
+                try:
+                    from cryptography.hazmat.primitives import serialization
+
+                    public_key_obj = load_der_public_key(public_key_pem)
+                    public_key_pem = public_key_obj.public_bytes(
+                        encoding=serialization.Encoding.PEM,
+                        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+                    ).decode("utf-8")
+                    logger.debug("Converted DER public key to PEM format")
+                except Exception as e:
+                    logger.error(f"Failed to decode public key: {e}")
+                    raise ValueError(f"Unable to decode public key: {e}")
+
+        export_data = {
+            "format": "raw",
+            "wrapPublicKey": public_key_pem,
+            "wrapPublicKeyPadding": "oaep256",  # Use OAEP with SHA-256
+        }
+
+        response = self._make_request(
+            "POST", f"vault/keys2/{wrapping_key_id}/export", json=export_data
+        )
+
+        if response.status_code == 200:
+            result = response.json()
+            material = result.get("material", "")
+            logger.info(
+                f"Successfully wrapped AES key with RSA public key, material length: {len(material)} chars"
+            )
+            return result
+        else:
+            logger.error(
+                f"RSA key wrapping failed: {response.status_code} - {response.text}"
+            )
+            raise Exception(
+                f"Thales CTM RSA key wrapping failed: {response.status_code}"
+            )
+
+
+def kbm_open_client_connection(config_file: str = None):
+    """
+    Initialize the Thales CTM KBM client.
+
+    Config file (YAML or JSON) format:
+      host: "ctm-hostname.example.com"
+      verify_ssl: true  # optional, defaults to true
+      ca_certfile: "/path/to/ca.pem"  # required if verify_ssl is true
+      certificate_login: false  # optional, defaults to false
+
+      # For password authentication (certificate_login: false):
+      username: "ctm_user"
+      password: "ctm_password"
+
+      # For certificate authentication (certificate_login: true):
+      auth_certfile: "/path/to/client.pem"
+      auth_keyfile: "/path/to/client.key"
+    """
+    logger.info("Initializing Thales CTM KBM client connection")
+    cfg = _load_config_file(config_file)
+
+    # Extract connection parameters
+    host = cfg.get("host")
+    verify_ssl = cfg.get("verify_ssl", False)
+    ca_cert = cfg.get("ca_certfile")
+    certificate_login = cfg.get("certificate_login", False)
+
+    if not host:
+        raise ValueError("Thales CTM host is required in config file")
+
+    # Authentication parameters
+    username = cfg.get("username")
+    password = cfg.get("password")
+    cert_file = cfg.get("auth_certfile")
+    key_file = cfg.get("auth_keyfile")
+    domain = cfg.get("domain", "root")  # Default to 'root' if not specified
+    key_wrap_algorithm = cfg.get("key_wrap_algorithm", "AES-KWP")
+    requests_timeout = cfg.get(
+        "requests_timeout"
+    )  # Timeout in seconds for HTTP requests
+    if requests_timeout is not None:
+        requests_timeout = int(requests_timeout)  # Ensure it's an integer
+
+    logger.info(f"Thales CTM KBM client initialized for host: {host}")
+    return _CTMKBMClient(
+        host=host,
+        verify_ssl=verify_ssl,
+        ca_cert=ca_cert,
+        username=username,
+        password=password,
+        cert_file=cert_file,
+        key_file=key_file,
+        certificate_login=certificate_login,
+        domain=domain,
+        key_wrap_algorithm=key_wrap_algorithm,
+        requests_timeout=requests_timeout,
+    )
+
+
+def kbm_close_client_connection(kmip_client) -> None:
+    """Close the Thales CTM KBM client connection"""
+    logger.info("Closing Thales CTM KBM client connection")
+    # No special cleanup needed for CTM client
+    return None
+
+
+def kbm_get_secret(kmip_client, key_id: str, wrapping_key: bytes):
+    """
+    Get and wrap a secret from Thales CTM.
+
+    Returns dict: {"wrapped_key": b64, "blob": b64, "iv": b64, "tag": b64}
+    """
+    if not isinstance(kmip_client, _CTMKBMClient):
+        logger.error("Invalid client handle provided")
+        raise ValueError("Invalid client handle")
+    if not key_id:
+        logger.error("key_id is required but not provided")
+        raise ValueError("key_id required")
+    if not wrapping_key:
+        logger.error("wrapping_key is required but not provided")
+        raise ValueError("wrapping_key (client RSA public key) is required")
+
+    return kmip_client.get_secret(key_id, wrapping_key)
+
+
+__all__ = [
+    # Public KBM plugin API
+    "kbm_open_client_connection",
+    "kbm_close_client_connection",
+    "kbm_get_secret",
+]


### PR DESCRIPTION
Add complete integration for Thales CipherTrust Manager as a Key Management Backend provider.

- Add tas_kbm_thales_ctm.py plugin with full CTM API client implementation
  * Support for certificate-based and password-based authentication
  * Configurable SSL verification with CA certificate support
  * Request retry logic with exponential backoff for reliability
  * Key generation, wrapping, and deletion operations via CTM REST API
  * AES Key Wrap (RFC 5649) for secret wrapping with RSA public key encryption

- Add thales_ctm.yaml configuration template
  * Support for environment variable substitution in config
  * Settings for host, authentication method, SSL verification, key wrap algorithm

- Add certs/thales_ctm/ directory with comprehensive documentation
  * Step-by-step guide for obtaining CA certificates from CTM
  * Instructions for certificate-based login setup
  * CSR generation and CTM CA signing process
  * Security best practices for private key permissions

- Add .gitignore to exclude sensitive certificate files from version control

Supports both authentication methods:
- Password authentication (username/password via environment variables)
- Certificate-based authentication (client cert/key for enhanced security)