### PR TITLE
Remove signed_data field from policies, signatures must cover entire policy

### DIFF
--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -104,7 +104,8 @@ Policies are stored in Redis and referenced during attestation validation to det
 | `algorithm` | string | Yes | Algorithm used |
 | `padding` | string | Yes | Padding (either PSS or PKCS1v15) |
 | `value` | string | Yes | Base64 encoded signature |
-| `signed_data` | string or list | No | Specifies which fields are signed. If omitted, the signature covers all top-level fields except `signature`. Can be a single field name (e.g. `"validation_rules"`) or a list (e.g. `["metadata", "validation_rules"]`). |
+
+> **Deprecation Notice**: The `signed_data` field previously allowed specifying which fields are covered by the signature. This field is **no longer supported**. The signature must always cover all top-level fields except `signature`. Policies using `signed_data` must be re-signed.
 
 ### TDX Specific Fields
 ##### TCB
@@ -135,9 +136,7 @@ Policy signing provides:
 
 Before signing or verifying, TAS canonicalizes the policy JSON using [RFC 8785 (JSON Canonicalization Scheme / JCS)](https://www.rfc-editor.org/rfc/rfc8785). This ensures that logically equivalent JSON objects produce identical byte representations regardless of key ordering or whitespace. The canonicalized bytes are then signed with RSA using SHA-384 and either PSS or PKCS1v15 padding.
 
-By default, the signature covers **all top-level fields** in the policy (metadata, validation_rules, etc.) except the `signature` field itself. This means any change to the policy will invalidate the signature.
-
-If you need the signature to cover only specific fields, you can add a `signed_data` field to the signature object specifying which field(s) to sign. For example, `"signed_data": "validation_rules"` will sign only the validation rules, allowing metadata to be changed without invalidating the signature.
+The signature covers **all top-level fields** in the policy (metadata, validation_rules, etc.) except the `signature` field itself. This means any change to the policy will invalidate the signature.
 
 > **Note:** Policies must be signed using RFC 8785 canonicalization. Any custom signing tool must canonicalize the policy to be signed with JCS before signing.
 

--- a/tas/management_routes.py
+++ b/tas/management_routes.py
@@ -95,6 +95,20 @@ def store_policy():
         )
 
     is_signed = "signature" in policy
+    if is_signed and "signed_data" in policy.get("signature", {}):
+        logger.error(
+            f"Policy {policy_type}:{key_id} uses deprecated 'signed_data' field"
+        )
+        return (
+            jsonify(
+                {
+                    "error": "The 'signed_data' field in the signature object is deprecated and no longer supported. "
+                    "Please re-sign the policy so that the signature covers all top-level fields."
+                }
+            ),
+            400,
+        )
+
     warning_message = None
     if not is_signed:
         logger.warning(f"Policy {policy_type}:{key_id} is not signed")
@@ -111,18 +125,12 @@ def store_policy():
             )
     else:
         logger.info(f"Policy {policy_type}:{key_id} is signed")
-        if not current_app.config.get("TAS_ENFORCE_SIGNED_POLICIES", True):
-            logger.warning(
-                "Signed policy not verified - policy signature check is disabled"
-            )
-            warning_message = "WARNING: Signed policy not verified - policy signature check is disabled"
-        else:
-            if not verify_policy_signature(
-                policy, current_app.config.get("TAS_TRUSTED_KEYS", [])
-            ):
-                logger.error("Policy signature verification failed")
-                return jsonify({"error": "Policy signature verification failed"}), 400
-            logger.info("Policy signature verification successful")
+        if not verify_policy_signature(
+            policy, current_app.config.get("TAS_TRUSTED_KEYS", [])
+        ):
+            logger.error("Policy signature verification failed")
+            return jsonify({"error": "Policy signature verification failed"}), 400
+        logger.info("Policy signature verification successful")
 
     try:
         redis_client = _get_redis()

--- a/tas/policy_helper.py
+++ b/tas/policy_helper.py
@@ -57,41 +57,20 @@ def verify_policy_signature(policy_data, public_keys):
             f"Signature padding scheme: {signature_info.get('padding', 'PSS')}"
         )
 
+        # Reject deprecated signed_data field
+        if "signed_data" in signature_info:
+            logger.error(
+                "The 'signed_data' field in the signature object is deprecated and no longer supported. "
+                "Policies must be re-signed so that the signature covers all top-level fields except 'signature'."
+            )
+            return False
+
         # Decode the signature
         signature_b64 = signature_info["value"]
         signature = base64.b64decode(signature_b64)
         logger.debug(f"Decoded signature length: {len(signature)} bytes")
 
-        # Determine what data is covered by the signature
-        signed_data_spec = signature_info.get("signed_data")
-
-        if signed_data_spec is not None:
-            # signed_data specified: sign only those fields
-            if isinstance(signed_data_spec, str):
-                signed_data_spec = [signed_data_spec]
-
-            if not isinstance(signed_data_spec, list) or not signed_data_spec:
-                logger.error(
-                    "signed_data must be a non-empty string or list of strings"
-                )
-                return False
-
-            logger.debug(f"Signature covers specified fields: {signed_data_spec}")
-            for field in signed_data_spec:
-                if field not in policy_data:
-                    logger.error(
-                        f"signed_data field '{field}' not found in policy data"
-                    )
-                    return False
-
-            data_to_verify = {f: policy_data[f] for f in signed_data_spec}
-            signed_json = canonicalize_policy(data_to_verify)
-        else:
-            # Default: signature covers all top-level fields except "signature"
-            logger.debug(
-                "No signed_data specified, signature covers all fields except 'signature'"
-            )
-            signed_json = canonicalize_policy(policy_data)
+        signed_json = canonicalize_policy(policy_data)
         logger.debug(
             f"Prepared data for verification, length: {len(signed_json)} bytes"
         )

--- a/tests/test_policy_helper.py
+++ b/tests/test_policy_helper.py
@@ -34,7 +34,7 @@ class TestVerifyPolicySignature:
 
     @pytest.fixture
     def sample_policy_data(self):
-        """Policy with signed_data targeting only validation_rules."""
+        """Policy with signature covering all fields."""
         return {
             "metadata": {"name": "Test Policy", "version": "1.0"},
             "validation_rules": {
@@ -47,35 +47,6 @@ class TestVerifyPolicySignature:
                 "algorithm": "SHA384",
                 "padding": "PSS",
                 "value": "",
-                "signed_data": "validation_rules",
-            },
-        }
-
-    @pytest.fixture
-    def default_signed_policy_data(self):
-        """Policy without signed_data — signature covers all fields."""
-        return {
-            "metadata": {"name": "Test Policy", "version": "1.0"},
-            "validation_rules": {
-                "measurement": {"exact_match": "12ab34cd56ef"},
-                "version": {"min_value": 3},
-            },
-            "signature": {"algorithm": "SHA384", "padding": "PSS", "value": ""},
-        }
-
-    @pytest.fixture
-    def multi_signed_policy_data(self):
-        """Policy with signed_data as a list of multiple fields."""
-        return {
-            "metadata": {"name": "Test Policy", "version": "1.0"},
-            "validation_rules": {
-                "measurement": {"exact_match": "12ab34cd56ef"},
-            },
-            "signature": {
-                "algorithm": "SHA384",
-                "padding": "PSS",
-                "value": "",
-                "signed_data": ["metadata", "validation_rules"],
             },
         }
 
@@ -83,16 +54,7 @@ class TestVerifyPolicySignature:
         """Helper method to create a valid signature for test data."""
         from tas.policy_helper import canonicalize_policy
 
-        signed_data_spec = policy_data.get("signature", {}).get("signed_data")
-
-        if signed_data_spec is not None:
-            if isinstance(signed_data_spec, str):
-                signed_data_spec = [signed_data_spec]
-            data_to_sign = {k: policy_data[k] for k in signed_data_spec}
-        else:
-            data_to_sign = policy_data
-
-        data_json = canonicalize_policy(data_to_sign)
+        data_json = canonicalize_policy(policy_data)
 
         # Create signature
         if padding_scheme == "PSS":
@@ -370,39 +332,8 @@ class TestVerifyPolicySignature:
         assert result1 is True
         assert result2 is True
 
-    def test_default_signs_all_fields(self, rsa_key_pair, default_signed_policy_data):
-        """Test that without signed_data, signature covers all fields except signature."""
-        private_key, public_key = rsa_key_pair
-
-        signature_b64 = self.create_valid_signature(
-            default_signed_policy_data, private_key
-        )
-        default_signed_policy_data["signature"]["value"] = signature_b64
-
-        public_keys = [("RSA", "test_key.pem", public_key)]
-        result = verify_policy_signature(default_signed_policy_data, public_keys)
-        assert result is True
-
-    def test_default_metadata_change_breaks_signature(
-        self, rsa_key_pair, default_signed_policy_data
-    ):
-        """Test that modifying metadata breaks signature when no signed_data specified."""
-        private_key, public_key = rsa_key_pair
-
-        signature_b64 = self.create_valid_signature(
-            default_signed_policy_data, private_key
-        )
-        default_signed_policy_data["signature"]["value"] = signature_b64
-
-        # Modify metadata after signing
-        default_signed_policy_data["metadata"]["version"] = "2.0"
-
-        public_keys = [("RSA", "test_key.pem", public_key)]
-        result = verify_policy_signature(default_signed_policy_data, public_keys)
-        assert result is False
-
-    def test_signed_data_single_field_string(self, rsa_key_pair, sample_policy_data):
-        """Test signed_data as a single string field name."""
+    def test_default_signs_all_fields(self, rsa_key_pair, sample_policy_data):
+        """Test that signature covers all fields except signature."""
         private_key, public_key = rsa_key_pair
 
         signature_b64 = self.create_valid_signature(sample_policy_data, private_key)
@@ -412,38 +343,28 @@ class TestVerifyPolicySignature:
         result = verify_policy_signature(sample_policy_data, public_keys)
         assert result is True
 
-    def test_signed_data_allows_metadata_change(self, rsa_key_pair, sample_policy_data):
-        """Test that with signed_data=validation_rules, changing metadata does not break sig."""
+    def test_default_metadata_change_breaks_signature(
+        self, rsa_key_pair, sample_policy_data
+    ):
+        """Test that modifying metadata breaks signature."""
         private_key, public_key = rsa_key_pair
 
         signature_b64 = self.create_valid_signature(sample_policy_data, private_key)
         sample_policy_data["signature"]["value"] = signature_b64
 
-        # Modify metadata after signing - should NOT break signature
+        # Modify metadata after signing
         sample_policy_data["metadata"]["version"] = "2.0"
 
         public_keys = [("RSA", "test_key.pem", public_key)]
         result = verify_policy_signature(sample_policy_data, public_keys)
-        assert result is True
+        assert result is False
 
-    def test_signed_data_list_of_fields(self, rsa_key_pair, multi_signed_policy_data):
-        """Test signed_data as a list of multiple field names."""
-        private_key, public_key = rsa_key_pair
-
-        signature_b64 = self.create_valid_signature(
-            multi_signed_policy_data, private_key
-        )
-        multi_signed_policy_data["signature"]["value"] = signature_b64
-
-        public_keys = [("RSA", "test_key.pem", public_key)]
-        result = verify_policy_signature(multi_signed_policy_data, public_keys)
-        assert result is True
-
-    def test_signed_data_missing_field(self, rsa_key_pair):
-        """Test that signed_data referencing a missing field returns False."""
+    def test_signed_data_field_is_rejected(self, rsa_key_pair):
+        """Test that policies with deprecated signed_data field are rejected."""
         _, public_key = rsa_key_pair
 
         policy_data = {
+            "metadata": {"name": "Test Policy", "version": "1.0"},
             "validation_rules": {
                 "measurement": {"exact_match": "12ab34cd56ef"},
             },
@@ -451,7 +372,28 @@ class TestVerifyPolicySignature:
                 "algorithm": "SHA384",
                 "padding": "PSS",
                 "value": base64.b64encode(b"test").decode("utf-8"),
-                "signed_data": "nonexistent_field",
+                "signed_data": "validation_rules",
+            },
+        }
+
+        public_keys = [("RSA", "test_key.pem", public_key)]
+        result = verify_policy_signature(policy_data, public_keys)
+        assert result is False
+
+    def test_signed_data_list_is_rejected(self, rsa_key_pair):
+        """Test that policies with signed_data as a list are rejected."""
+        _, public_key = rsa_key_pair
+
+        policy_data = {
+            "metadata": {"name": "Test Policy", "version": "1.0"},
+            "validation_rules": {
+                "measurement": {"exact_match": "12ab34cd56ef"},
+            },
+            "signature": {
+                "algorithm": "SHA384",
+                "padding": "PSS",
+                "value": base64.b64encode(b"test").decode("utf-8"),
+                "signed_data": ["metadata", "validation_rules"],
             },
         }
 


### PR DESCRIPTION
The signed_data field in the policy signature object allowed specifying a subset of fields covered by the signature. This created unnecessary complexity and weakened integrity guarantees by allowing unsigned fields to be modified. This PR removes support entirely, the signature must now always cover all top-level fields except signature itself.

### Changes
policy_helper.py: Replaced signed_data handling logic with an explicit rejection that returns False and logs a clear deprecation error
management_routes.py: Added early validation in store_policy to return a 400 with an actionable error message before reaching signature verification
docs/POLICY.md: Removed signed_data from the signature fields table, added a deprecation notice, and removed usage instructions
tests/test_policy_helper.py: Removed signed_data-based fixtures and tests; added test_signed_data_field_is_rejected and test_signed_data_list_is_rejected

### Migration
Policies containing signed_data in their signature object must be re-signed without the field so that the signature covers the full policy.

