### PR TITLE
Remove remnant pykmip cert directory

### DIFF
--- a/certs/pykmip/.gitignore
+++ b/certs/pykmip/.gitignore
@@ -1,6 +1,0 @@
-# Add any pykmip certificates to this directory
-#
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore


### PR DESCRIPTION
Pykmip was removed months ago but that removal missed the certs/pykmip directory. This commit removes that directory.