### PR TITLE
Unsigned checks for the presence of value in signature

### DIFF
--- a/tas/management_routes.py
+++ b/tas/management_routes.py
@@ -17,6 +17,7 @@ from flask import Blueprint, current_app, jsonify, request
 from .auth import authenticate_management_request
 from .policy_helper import (
     POLICY_KEY_COMPONENT_RE,
+    is_policy_signed,
     validate_policy_key,
     verify_policy_signature,
 )
@@ -94,7 +95,7 @@ def store_policy():
             400,
         )
 
-    is_signed = "signature" in policy
+    is_signed = is_policy_signed(policy)
     if is_signed and "signed_data" in policy.get("signature", {}):
         logger.error(
             f"Policy {policy_type}:{key_id} uses deprecated 'signed_data' field"
@@ -184,7 +185,7 @@ def get_policy(policy_key):
         logger.info(f"Successfully retrieved policy '{policy_key}'")
 
         response_data = {"policy_key": policy_key, "policy": policy}
-        if "signature" not in policy:
+        if not is_policy_signed(policy):
             logger.warning(f"Retrieved policy '{policy_key}' is not signed")
             response_data[
                 "warning"
@@ -227,7 +228,7 @@ def list_policies():
                         "name": metadata.get("name", "Unknown"),
                         "version": metadata.get("version", "Unknown"),
                         "description": metadata.get("description", "No description"),
-                        "signed": "signature" in policy,
+                        "signed": is_policy_signed(policy),
                     }
                     policies.append(policy_info)
                     logger.debug(f"Added policy to list: {key}")

--- a/tas/policy_helper.py
+++ b/tas/policy_helper.py
@@ -25,6 +25,25 @@ from .tas_logging import get_logger
 logger = get_logger(__name__)
 
 
+def is_policy_signed(policy_data):
+    """Determine if a policy is signed.
+
+    A policy is considered signed only if it has a 'signature' field
+    containing a 'value' sub-field. A policy missing 'signature' entirely,
+    or having 'signature' without 'value', is considered unsigned.
+
+    Args:
+        policy_data: The policy data dict.
+
+    Returns:
+        bool: True if the policy has a signature with a value, False otherwise.
+    """
+    signature = policy_data.get("signature")
+    if not isinstance(signature, dict):
+        return False
+    return "value" in signature
+
+
 def verify_policy_signature(policy_data, public_keys):
     """Verify the signature in a policy against a list of public keys.
 

--- a/tas/tas_vm.py
+++ b/tas/tas_vm.py
@@ -22,7 +22,7 @@ from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 from flask import current_app
 
-from tas.policy_helper import verify_policy_signature
+from tas.policy_helper import is_policy_signed, verify_policy_signature
 from tas.tas_logging import get_logger, log_function_entry, log_function_exit
 
 # Setup logging for verification output
@@ -431,7 +431,7 @@ def get_policy_from_redis(redis_client: redis.StrictRedis, policy_key: str):
         logger.error(f"Failed to parse policy JSON: {e}")
         raise ValueError("Invalid policy format")
 
-    if not policy_json.get("signature"):
+    if not is_policy_signed(policy_json):
         # Policy is not signed
         if current_app.config.get("TAS_ENFORCE_SIGNED_POLICIES", True):
             logger.error(f"Policy '{policy_key}' is not signed and signing is required")


### PR DESCRIPTION
Added is_policy_signed function which only considers a policy signed if both the signature top-level fields exists and there is a value for the signature within it.