### PR TITLE
Add MAX_CONTENT_LENGTH (2 MB) to protect against oversized request pa…

### DIFF
--- a/config/tas_config.yaml
+++ b/config/tas_config.yaml
@@ -8,6 +8,7 @@
 #TRAP_HTTP_EXCEPTIONS: false
 #TRAP_BAD_REQUEST_ERRORS: null
 #SESSION_COOKIE_NAME: "tas_session"
+#MAX_CONTENT_LENGTH: 2097152  # 2 MB; increase for multi-GPU attestation servers
 
 # Server binding (used by app.run)
 SERVER_BIND_HOST: "0.0.0.0"

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -109,6 +109,7 @@ export TAS_OVERRIDE__logging__file="/var/log/tas.log"
   - JSON_SORT_KEYS (bool)
   - JSONIFY_PRETTYPRINT_REGULAR (bool)
   - PROPAGATE_EXCEPTIONS (bool, optional)
+  - MAX_CONTENT_LENGTH (int) — Maximum request body size in bytes. Default `2097152` (2 MB). Increase for multi-GPU attestation (e.g. `4194304` for 16+ GPUs). Set via `FLASK_MAX_CONTENT_LENGTH` env var or `MAX_CONTENT_LENGTH` in YAML config.
 
 ### TAS-specific keys
 

--- a/tas/config.py
+++ b/tas/config.py
@@ -29,6 +29,7 @@ class BaseConfig:
     TRAP_HTTP_EXCEPTIONS = False
     TRAP_BAD_REQUEST_ERRORS = None
     SESSION_COOKIE_NAME = "tas_session"
+    MAX_CONTENT_LENGTH = 2 * 1024 * 1024  # 2 MB
 
     # TAS specifics
     # TODO remove getenv and use hardcoded defaults as we will overide with env vars in later stages

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -8,7 +8,7 @@
 #
 
 import pytest
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 from werkzeug.exceptions import BadRequest, Forbidden, HTTPException, Unauthorized
 
 from tas.error_handlers import register_error_handlers
@@ -135,3 +135,24 @@ class TestNormalRoutes:
         resp = client.get("/ok")
         assert resp.status_code == 200
         assert resp.get_json() == {"status": "ok"}
+
+
+class TestRequestSizeLimits:
+    """Verify that MAX_CONTENT_LENGTH triggers a 413 response."""
+
+    def test_request_entity_too_large_returns_413(self, app, client):
+        app.config["MAX_CONTENT_LENGTH"] = 1024  # 1 KB limit for test
+
+        @app.route("/upload", methods=["POST"])
+        def upload():
+            _ = request.get_data()  # triggers MAX_CONTENT_LENGTH check
+            return jsonify({"status": "ok"}), 200
+
+        # Send a payload larger than the limit
+        oversized = b"x" * 2048
+        resp = client.post(
+            "/upload", data=oversized, content_type="application/octet-stream"
+        )
+        assert resp.status_code == 413
+        data = resp.get_json()
+        assert "error" in data


### PR DESCRIPTION
…yloads

- Set 2 MB default in BaseConfig, overridable via env var or YAML config
- Add 413 test to verify JSON error response for oversized requests
- Document setting in CONFIG.md and tas_config.yaml