### PR TITLE
fix: default verify_ssl to True in Thales CTM plugin

### DIFF
--- a/plugins/tas_kbm_thales_ctm.py
+++ b/plugins/tas_kbm_thales_ctm.py
@@ -555,7 +555,13 @@ def kbm_open_client_connection(config_file: str = None):
 
     # Extract connection parameters
     host = cfg.get("host")
-    verify_ssl = cfg.get("verify_ssl", False)
+    verify_ssl = cfg.get("verify_ssl", True)
+    if not verify_ssl:
+        logger.warning(
+            "TLS certificate verification is DISABLED for Thales CTM connections "
+            "(verify_ssl=false in config). This is insecure and should only be used "
+            "for development/testing."
+        )
     ca_cert = cfg.get("ca_certfile")
     certificate_login = cfg.get("certificate_login", False)
 


### PR DESCRIPTION
The kbm_open_client_connection() function defaulted verify_ssl to False, silently disabling TLS certificate verification for key manager connections. This contradicted the docstring ("defaults to true") and exposed the CTM API channel to MITM attacks.