### PR TITLE
chore: upgrade black from 23.1.0 to 25.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,6 @@ repos:
         name: isort (python)
         args: ["--profile", "black"]
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 25.12.0
     hooks:
       - id: black

--- a/tas/management_routes.py
+++ b/tas/management_routes.py
@@ -187,9 +187,9 @@ def get_policy(policy_key):
         response_data = {"policy_key": policy_key, "policy": policy}
         if not is_policy_signed(policy):
             logger.warning(f"Retrieved policy '{policy_key}' is not signed")
-            response_data[
-                "warning"
-            ] = "WARNING: Policy is not signed and cannot be verified for integrity"
+            response_data["warning"] = (
+                "WARNING: Policy is not signed and cannot be verified for integrity"
+            )
 
         return jsonify(response_data), 200
 


### PR DESCRIPTION
Black 23.1.0 crashes on Python 3.12+ due to removed ast.Str node. Update to 25.12.0 for Python 3.10-3.14 support without adopting the 2026 stable style.

Ran 'pre-commit run black --all-files' to reformat files. only tas/management_routes.py was reformatted.