### PR TITLE
fix: prevent nonce replay with atomic GETDEL and require Redis 6.2+

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -48,6 +48,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y redis-server iproute2 psmisc
           redis-server --version
+          # Assert Redis >= 6.2 (required for GETDEL)
+          REDIS_VER=$(redis-server --version | grep -oP 'v=\K[0-9]+\.[0-9]+')
+          if python3 -c "assert tuple(int(x) for x in '$REDIS_VER'.split('.')) >= (6,2), f'Redis {"$REDIS_VER"} < 6.2'"; then
+            echo "Redis version $REDIS_VER OK (>= 6.2)"
+          else
+            echo "::error::Redis version $REDIS_VER is below the required 6.2"
+            exit 1
+          fi
           pip install --upgrade pip
           git clone https://github.com/TEE-Attestation/sev_pytools.git
           cd sev_pytools && pip install . && cd ..

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ pip install .
 cd ..
 pip install -r requirements.txt
 
-# 3. Start Redis (required)
+# 3. Start Redis 6.2+ (required)
 redis-server &
 
 # 4. Set environment variables
@@ -81,7 +81,7 @@ With TAS running you can use the [TAS agent](https://github.com/TEE-Attestation/
 ### Required Software
 
 - **Python** (>= 3.8)
-- **Redis**
+- **Redis** (>= 6.2)
 
 **Note:** If you want to use the KMIP KBM plugin, ensure PyKMIP is installed. Note that PyKMIP does not work on Python 3.12 or later because it relies on ssl.wrap_socket(), which was removed in Python 3.12, so your venv will need a Python version between 3.8 and 3.11.
 
@@ -565,7 +565,7 @@ Contributing to the project is simple! Just send a pull request through GitHub. 
 ```
 Error: Failed to connect to the Redis server
 ```
-**Solution**: Ensure Redis is running on the configured host/port
+**Solution**: Ensure Redis 6.2+ is running on the configured host/port
 ```bash
 redis-server &  # Start Redis
 redis-cli ping  # Test connectivity

--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ from tas.auth import authenticate_request, init_client_auth, init_management_aut
 from tas.config_loader import load_configuration
 from tas.error_handlers import register_error_handlers
 from tas.management_routes import management_bp
+from tas.nonce import check_redis_version, store_nonce, validate_nonce
 from tas.tas_logging import configure_external_logging, setup_logging
 from tas.tas_vm import vm_verify
 
@@ -148,6 +149,9 @@ try:
     # Test the connection to ensure Redis is reachable
     redis_client.ping()
     logger.info("Successful Connection to Redis Server")
+
+    check_redis_version(redis_client)
+
     if redis_password:
         logger.info("Redis AUTH enabled")
     else:
@@ -237,34 +241,6 @@ except Exception as e:
     raise RuntimeError(f"Failed to open KBM client connection: {e}")
 
 
-# Function to store a nonce with an expiration time
-def store_nonce(nonce):
-    logger.debug(f"Storing nonce with expiration: {NONCE_EXPIRATION_SECONDS}s")
-    redis_client.setex(nonce, NONCE_EXPIRATION_SECONDS, int(time.time()))
-    logger.debug("Nonce stored successfully")
-
-
-# Function to validate a nonce
-def validate_nonce(nonce):
-    logger.debug(f"Validating nonce: {nonce[:8]}...")
-    timestamp = redis_client.get(nonce)
-    if not timestamp:
-        logger.warning("Nonce validation failed: Invalid or expired nonce")
-        return False, "Invalid or expired nonce"
-
-    # Check if the nonce has expired
-    current_time = int(time.time())
-    if current_time - int(timestamp) > NONCE_EXPIRATION_SECONDS:
-        logger.warning("Nonce validation failed: Nonce has expired")
-        redis_client.delete(nonce)
-        return False, "Nonce has expired"
-
-    # Nonce is valid
-    logger.debug("Nonce validation successful, removing from Redis")
-    redis_client.delete(nonce)  # Remove nonce after successful validation
-    return True, None
-
-
 # Endpoint to generate and send a nonce
 @app.route("/kb/v0/get_nonce", methods=["GET"])
 def get_nonce():
@@ -278,7 +254,7 @@ def get_nonce():
     logger.debug(f"Generated nonce: {nonce}")
 
     # Store the nonce in Redis
-    store_nonce(nonce)
+    store_nonce(redis_client, nonce, NONCE_EXPIRATION_SECONDS)
     logger.info("Nonce generated and stored successfully")
 
     return jsonify({"nonce": nonce})
@@ -311,7 +287,7 @@ def get_secret():
         return jsonify({"error": "Nonce is required"}), 400
 
     nonce = str(nonce).strip('"')
-    is_valid, error_message = validate_nonce(nonce)
+    is_valid, error_message = validate_nonce(redis_client, nonce)
     if not is_valid:
         logger.error(f"Nonce validation failed: {error_message}")
         return jsonify({"error": error_message}), 401

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -123,7 +123,7 @@ Stored in Flask's config; set directly via env without prefix:
 | TAS_MANAGEMENT_API_KEY | str | `""` | **Yes** | Shared secret used to authenticate management API requests (policy CRUD). Must be at least `TAS_MANAGEMENT_API_KEY_MIN_LENGTH` characters long. Sent via the `X-MANAGEMENT-API-KEY` header. |
 | TAS_MANAGEMENT_API_KEY_MIN_LENGTH | int | `64` | No | Minimum number of characters required for `TAS_MANAGEMENT_API_KEY`. The application refuses to start if the management key is shorter than this value. |
 | TAS_NONCE_EXPIRATION_SECONDS | int | `120` | No | Number of seconds a nonce remains valid after creation. Nonces older than this are rejected during attestation verification. |
-| TAS_REDIS_HOST | str | `"localhost"` | No | Hostname or IP address of the Redis server used for nonce storage, certificate caching, and policy storage. |
+| TAS_REDIS_HOST | str | `"localhost"` | No | Hostname or IP address of the Redis server (>= 6.2) used for nonce storage, certificate caching, and policy storage. TAS validates the server version at startup and refuses to start if Redis is older than 6.2. |
 | TAS_REDIS_PORT | int | `6379` | No | Port number of the Redis server. |
 | TAS_REDIS_PASSWORD | str | `""` | No | Redis AUTH password. When set, TAS authenticates to Redis on connection. Always set via environment variable, never in config files. |
 | TAS_REDIS_PERSISTENCE | bool | `true` | No | When `true`, TAS configures Redis AOF + RDB persistence at startup via `CONFIG SET`. Set to `false` if your Redis is externally managed or you want to use your own `redis.conf` settings. Check `GET /management/status` for runtime persistence state. See [REDIS_PERSISTENCE.md](REDIS_PERSISTENCE.md) for details. |

--- a/docs/REDIS_PERSISTENCE.md
+++ b/docs/REDIS_PERSISTENCE.md
@@ -1,6 +1,6 @@
 # Redis Persistence
 
-TAS stores security policies in Redis. By default, TAS automatically configures
+TAS requires **Redis 6.2 or later** (for the `GETDEL` command used in atomic nonce validation). TAS stores security policies in Redis. By default, TAS automatically configures
 Redis persistence at startup so policies survive Redis and host restarts. This
 is done via Redis `CONFIG SET` commands — no manual Redis configuration is needed.
 
@@ -110,7 +110,7 @@ AOF and RDB files. To protect them:
 2. **Signed policies**: Set `TAS_ENFORCE_SIGNED_POLICIES=true`. TAS re-verifies
    policy signatures at attestation time, so tampered AOF/RDB data is rejected.
 3. **Redis authentication**: Set `TAS_REDIS_PASSWORD` to require AUTH.
-4. **Redis ACLs** (Redis 6+): Restrict the TAS user to only the commands it
+4. **Redis ACLs** (Redis 6.2+, required by TAS): Restrict the TAS user to only the commands it
    needs.
 
 See [CONFIG.md](CONFIG.md) for the full configuration reference.

--- a/tas/nonce.py
+++ b/tas/nonce.py
@@ -1,0 +1,59 @@
+#
+# TEE Attestation Service - Nonce helpers
+#
+# Copyright 2026 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# This file is part of the TEE Attestation Service.
+# See LICENSE file for details.
+#
+
+from .tas_logging import get_logger
+
+logger = get_logger(__name__)
+
+
+MINIMUM_REDIS_VERSION = (6, 2)
+
+
+def check_redis_version(redis_client):
+    """Verify the Redis server is 6.2+ (required for GETDEL).
+
+    Returns the version string on success.
+    Raises ``RuntimeError`` if the server is too old.
+    """
+    version_str = redis_client.info("server").get("redis_version", "0.0.0")
+    version = tuple(int(x) for x in version_str.split(".")[:2])
+    if version < MINIMUM_REDIS_VERSION:
+        raise RuntimeError(
+            f"TAS requires Redis 6.2 or later (detected {version_str}). "
+            "Atomic nonce validation depends on the GETDEL command "
+            "introduced in Redis 6.2."
+        )
+    logger.info(f"Redis server version: {version_str}")
+    return version_str
+
+
+def store_nonce(redis_client, nonce, expiration_seconds):
+    """Store a nonce in Redis with a TTL.  The value is a sentinel; only
+    presence/absence matters."""
+    logger.debug(f"Storing nonce with expiration: {expiration_seconds}s")
+    redis_client.setex(nonce, expiration_seconds, "1")
+    logger.debug("Nonce stored successfully")
+
+
+def validate_nonce(redis_client, nonce):
+    """Atomically consume a nonce.  Returns ``(True, None)`` on success or
+    ``(False, error_message)`` if the nonce is missing / expired.
+
+    Uses ``GETDEL`` (Redis 6.2+) so the read-and-delete is a single
+    round-trip with no race window for concurrent replay.
+    """
+    logger.debug(f"Validating nonce: {nonce[:8]}...")
+    result = redis_client.getdel(nonce)
+    if not result:
+        logger.warning("Nonce validation failed: Invalid or expired nonce")
+        return False, "Invalid or expired nonce"
+
+    logger.debug("Nonce validation successful (consumed atomically)")
+    return True, None

--- a/tests/test_nonce_validation.py
+++ b/tests/test_nonce_validation.py
@@ -1,0 +1,118 @@
+#
+# TEE Attestation Service - Tests for Atomic Nonce Validation (F-01)
+#
+# Copyright 2026 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# This file is part of the TEE Attestation Service.
+#
+
+import pytest
+
+from tas.nonce import check_redis_version, store_nonce, validate_nonce
+
+
+class FakeRedis:
+    """Minimal in-memory Redis stub with GETDEL support."""
+
+    def __init__(self):
+        self._store = {}
+
+    def setex(self, key, ttl, value):
+        self._store[key] = value
+
+    def getdel(self, key):
+        return self._store.pop(key, None)
+
+    def get(self, key):
+        return self._store.get(key)
+
+    def info(self, section=None):
+        return {"redis_version": "7.2.0"}
+
+    def ping(self):
+        return True
+
+
+@pytest.fixture()
+def fake_redis():
+    return FakeRedis()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for atomic nonce consumption (real production functions)
+# ---------------------------------------------------------------------------
+
+NONCE_EXPIRATION_SECONDS = 600
+
+
+class TestStoreAndValidateNonce:
+    """Test the real store_nonce / validate_nonce from tas.nonce."""
+
+    def test_valid_nonce_consumed(self, fake_redis):
+        """A stored nonce is consumed on first validation."""
+        nonce = "aabbccdd" * 8
+        store_nonce(fake_redis, nonce, NONCE_EXPIRATION_SECONDS)
+        is_valid, err = validate_nonce(fake_redis, nonce)
+        assert is_valid is True
+        assert err is None
+
+    def test_replay_rejected(self, fake_redis):
+        """A nonce cannot be validated twice (replay prevention)."""
+        nonce = "aabbccdd" * 8
+        store_nonce(fake_redis, nonce, NONCE_EXPIRATION_SECONDS)
+        validate_nonce(fake_redis, nonce)
+        is_valid, err = validate_nonce(fake_redis, nonce)
+        assert is_valid is False
+        assert err == "Invalid or expired nonce"
+
+    def test_unknown_nonce_rejected(self, fake_redis):
+        """A nonce that was never stored is rejected."""
+        is_valid, err = validate_nonce(fake_redis, "nonexistent")
+        assert is_valid is False
+        assert err == "Invalid or expired nonce"
+
+    def test_expired_nonce_rejected(self, fake_redis):
+        """A nonce that expired (removed by Redis TTL) is rejected."""
+        nonce = "expired1" * 8
+        store_nonce(fake_redis, nonce, NONCE_EXPIRATION_SECONDS)
+        # Simulate TTL expiration by removing the key
+        fake_redis._store.pop(nonce, None)
+        is_valid, err = validate_nonce(fake_redis, nonce)
+        assert is_valid is False
+        assert err == "Invalid or expired nonce"
+
+    def test_getdel_atomicity(self, fake_redis):
+        """GETDEL returns and removes in one call - no window for races."""
+        nonce = "atomic01" * 8
+        store_nonce(fake_redis, nonce, NONCE_EXPIRATION_SECONDS)
+        # After getdel the key must be gone
+        result = fake_redis.getdel(nonce)
+        assert result == "1"
+        assert fake_redis.get(nonce) is None
+
+
+class TestRedisVersionCheck:
+    """Test the real check_redis_version from tas.nonce."""
+
+    def test_version_ok(self):
+        r = FakeRedis()
+        r.info = lambda section=None: {"redis_version": "7.2.0"}
+        assert check_redis_version(r) == "7.2.0"
+
+    def test_version_exactly_6_2(self):
+        r = FakeRedis()
+        r.info = lambda section=None: {"redis_version": "6.2.0"}
+        assert check_redis_version(r) == "6.2.0"
+
+    def test_version_too_old(self):
+        r = FakeRedis()
+        r.info = lambda section=None: {"redis_version": "6.0.16"}
+        with pytest.raises(RuntimeError, match="requires Redis 6.2"):
+            check_redis_version(r)
+
+    def test_version_5_series(self):
+        r = FakeRedis()
+        r.info = lambda section=None: {"redis_version": "5.0.14"}
+        with pytest.raises(RuntimeError, match="requires Redis 6.2"):
+            check_redis_version(r)


### PR DESCRIPTION
Replace the non-atomic GET → DELETE nonce validation sequence with a single GETDEL call, closing a race window where concurrent requests could both consume the same nonce.

Changes:
- validate_nonce() now uses redis_client.getdel() for atomic consume
- Remove redundant manual timestamp expiry check (Redis TTL suffices)
- Simplify store_nonce() sentinel value from int(time.time()) to "1"
- Add Redis 6.2+ version check at startup (GETDEL requires it)
- Add 9 unit tests for nonce atomicity and version enforcement
- Update README, CONFIG.md, REDIS_PERSISTENCE.md for Redis 6.2+ min
- Assert Redis >= 6.2 in CI workflow before running tests