### PR TITLE
chore: Bump supported Python version to 3.10+

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ With TAS running you can use the [TAS agent](https://github.com/TEE-Attestation/
 
 ### Required Software
 
-- **Python** (>= 3.8)
+- **Python** (>= 3.10)
 - **Redis** (>= 6.2)
 
 **Note:** If you want to use the KMIP KBM plugin, ensure PyKMIP is installed. Note that PyKMIP does not work on Python 3.12 or later because it relies on ssl.wrap_socket(), which was removed in Python 3.12, so your venv will need a Python version between 3.8 and 3.11.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@
 [project]
 name = "TAS"
 version = "0.1.0-alpha"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Change supported Python version to 3.10+.
Python 3.8 and 3.9 are now end of life.