### PR TITLE
style: reformat test_tas_vm.py for black py310+ target

### DIFF
--- a/tests/test_tas_vm.py
+++ b/tests/test_tas_vm.py
@@ -428,9 +428,10 @@ class TestVmVerifyGpuEvidence:
                 "device-index": 0,
             },
         ]
-        with patch("tas.tas_vm.sev_vm_verify") as mock_sev, patch(
-            "tas.tas_vm.gpu_vm_verify"
-        ) as mock_gpu:
+        with (
+            patch("tas.tas_vm.sev_vm_verify") as mock_sev,
+            patch("tas.tas_vm.gpu_vm_verify") as mock_gpu,
+        ):
             mock_sev.return_value = (True, "test-key", None)
 
             vm_verify(


### PR DESCRIPTION
The previous commit bumped requires-python to >=3.10, which caused black to infer py310+ as the target version. This triggers black's parenthesized context manager formatting (PEP 617), reformatting multi-context-manager with statements. This commit applies the auto-formatting that was missed in the original bump.