### PR TITLE
feat: add rate limiting to client API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ TAS provides:
 - **Key Management**: Secure key retrieval with cryptographic nonce validation
 - **Policy Management**: Store and validate security policies for attestation
 - **Pluggable Architecture**: Support for multiple Key Broker Modules (KBM)
+- **Rate Limiting**: Per-IP rate limiting on client routes with configurable limits and proxy-aware keying
 
 ![Simplified TAS Architecture](docs/images/simpleTAS.png)
 

--- a/app.py
+++ b/app.py
@@ -1,32 +1,29 @@
 #
 # TEE Attestation Service
 #
-# Copyright 2025 Hewlett Packard Enterprise Development LP.
+# Copyright 2025 - 2026 Hewlett Packard Enterprise Development LP.
 # SPDX-License-Identifier: MIT
 #
 # This file is part of the TEE Attestation Service.
 # See LICENSE file for details.
 #
 
-import base64
 import importlib
-import json
 import os
 import pkgutil
-import secrets
 import sys
-import time
 
 import redis
-from flask import Flask, jsonify, request
+from flask import Flask, request
 
-from tas.auth import authenticate_request, init_client_auth, init_management_auth
-from tas.config_loader import load_configuration
+from tas.auth import init_client_auth, init_management_auth
+from tas.client_routes import client_bp
+from tas.config_loader import load_configuration, resolve_ratelimit_storage
 from tas.error_handlers import register_error_handlers
 from tas.management_routes import management_bp
-from tas.nonce import check_redis_version, store_nonce, validate_nonce
+from tas.nonce import check_redis_version
+from tas.rate_limiter import setup_rate_limiter
 from tas.tas_logging import configure_external_logging, setup_logging
-from tas.tas_vm import vm_verify
 
 # Initialize Flask app and load configuration
 app = Flask(__name__)
@@ -68,8 +65,6 @@ else:
 
 # Include logging settings in external loggers
 configure_external_logging()
-
-
 # add ./plugins in sys.path
 fpath = os.path.join(os.path.dirname(__file__), "plugins")
 sys.path.append(fpath)
@@ -101,8 +96,6 @@ def log_response_info(response):
 
 
 register_error_handlers(app)
-
-
 # Optionally add an extra plugin directory to sys.path
 extra_plugin_dir = app.config.get("TAS_EXTRA_PLUGIN_DIR")
 if extra_plugin_dir:
@@ -112,17 +105,11 @@ if extra_plugin_dir:
     else:
         raise RuntimeError(f"Extra plugin directory does not exist: {extra_plugin_dir}")
 
-# TEE Attestation Service version information
-TAS_VERSION = "0.1.0"
-
 # Retrieve the API key from configuration
 TAS_API_KEY = app.config["TAS_API_KEY"]
 
 if not TAS_API_KEY:
     raise RuntimeError("TAS_API_KEY environment variable is not set")
-
-# Internal variables
-NONCE_EXPIRATION_SECONDS = app.config["TAS_NONCE_EXPIRATION_SECONDS"]
 
 # Plugin discovery: respect prefix defined in the configuration
 # This allows for dynamic loading of plugins that follow the
@@ -197,8 +184,55 @@ else:
 app.extensions["redis"] = redis_client
 app.extensions["redis_config_rewrite_ok"] = _redis_config_rewrite_ok
 
+# Initialize optional ephemeral Redis client for nonces and rate-limit counters
+_ephemeral_redis_uri = (app.config.get("TAS_EPHEMERAL_REDIS_URI") or "").strip()
+if _ephemeral_redis_uri:
+    try:
+        _ephemeral_kwargs = {"decode_responses": True}
+        _ephemeral_password = app.config.get("TAS_EPHEMERAL_REDIS_PASSWORD", "")
+        if _ephemeral_password:
+            _ephemeral_kwargs["password"] = _ephemeral_password
+        ephemeral_redis_client = redis.StrictRedis.from_url(
+            _ephemeral_redis_uri, **_ephemeral_kwargs
+        )
+        ephemeral_redis_client.ping()
+        logger.info("Successful connection to ephemeral Redis")
+
+        check_redis_version(ephemeral_redis_client)
+
+        app.extensions["redis_ephemeral"] = ephemeral_redis_client
+    except redis.ConnectionError as e:
+        raise RuntimeError(f"Failed to connect to ephemeral Redis: {e}")
+    except Exception as e:
+        raise RuntimeError(
+            f"An unexpected error occurred while initializing ephemeral Redis: {e}"
+        )
+else:
+    logger.info(
+        "No ephemeral Redis configured — nonces and rate limiting use primary Redis"
+    )
+
 # Register blueprints
 app.register_blueprint(management_bp)
+app.register_blueprint(client_bp)
+
+# Rate limiting storage resolution
+_rl_storage_uri, _rl_storage_options, _rl_mode = resolve_ratelimit_storage(
+    app.config, redis_client
+)
+logger.info("Rate limiter storage: %s", _rl_mode)
+
+if app.config.get("TAS_TRUST_X_FORWARDED_FOR"):
+    logger.warning(
+        "TAS_TRUST_X_FORWARDED_FOR is enabled — rate limiting will use "
+        "X-Forwarded-For header for client IP. Only enable this when TAS "
+        "is behind a trusted reverse proxy; otherwise clients can spoof "
+        "their IP to bypass rate limits."
+    )
+
+# Apply rate limit to all client blueprint routes
+limiter = setup_rate_limiter(app, client_bp, _rl_storage_uri, _rl_storage_options)
+
 
 # log discovered plugins for debugging
 logger.debug("Discovered plugins:")
@@ -212,8 +246,6 @@ if not tas_kbm_plugin:
 
 # log the selected tas_kbm plugin for debugging
 logger.info(f"Using tas_kbm plugin: {app.config['TAS_KBM_PLUGIN']}")
-
-
 # Ensure the tas_kbm plugin has the required functions
 required_functions = [
     "kbm_get_secret",
@@ -236,160 +268,16 @@ try:
         config_file=app.config["TAS_KBM_CONFIG_FILE"]
     )
     logger.info("KBM client connection established successfully")
+    app.extensions["kbm_client"] = kbm_client
+    app.extensions["kbm_get_secret"] = kbm_get_secret
 except Exception as e:
     logger.error(f"Failed to initialize KBM client: {e}")
     raise RuntimeError(f"Failed to open KBM client connection: {e}")
 
-
-# Endpoint to generate and send a nonce
-@app.route("/kb/v0/get_nonce", methods=["GET"])
-def get_nonce():
-    logger.info(f"Received nonce request from {request.remote_addr}")
-    auth_response = authenticate_request()
-    if auth_response:
-        return auth_response
-
-    # Generate a random nonce
-    nonce = secrets.token_hex(32)  # Generate a 64-character nonce
-    logger.debug(f"Generated nonce: {nonce}")
-
-    # Store the nonce in Redis
-    store_nonce(redis_client, nonce, NONCE_EXPIRATION_SECONDS)
-    logger.info("Nonce generated and stored successfully")
-
-    return jsonify({"nonce": nonce})
-
-
-# Endpoint to validate the nonce and return the secret key
-@app.route("/kb/v0/get_secret", methods=["POST"])
-def get_secret():
-    logger.info(f"Received secret request from {request.remote_addr}")
-    auth_response = authenticate_request()
-    if auth_response:
-        return auth_response
-
-    # Get the JSON data from the request
-    data = request.get_json()
-    if not data:
-        logger.error("Secret request missing JSON body")
-        return jsonify({"error": "Request body is required"}), 400
-
-    # Validate the "tee-type" field early
-    tee_type = data.get("tee-type")
-    if tee_type not in ["amd-sev-snp", "intel-tdx"]:
-        logger.error(f"Invalid TEE type received: {tee_type}")
-        return jsonify({"error": "Invalid or missing 'tee-type' field"}), 400
-
-    # Validate the "nonce" field
-    nonce = data.get("nonce")
-    if not nonce:
-        logger.error("Secret request missing nonce field")
-        return jsonify({"error": "Nonce is required"}), 400
-
-    nonce = str(nonce).strip('"')
-    is_valid, error_message = validate_nonce(redis_client, nonce)
-    if not is_valid:
-        logger.error(f"Nonce validation failed: {error_message}")
-        return jsonify({"error": error_message}), 401
-
-    # Validate the "tee-evidence" field
-    tee_evidence = data.get("tee-evidence")
-    if not tee_evidence:
-        logger.error("Secret request missing TEE evidence")
-        return jsonify({"error": "TEE evidence is required"}), 400
-
-    # Validate the "policy-id" field
-    policy_id = data.get("policy-id")
-    if not policy_id:
-        logger.error("Secret request missing policy ID")
-        return jsonify({"error": "Policy ID is required"}), 400
-
-    # Log the fields for debugging
-    logger.debug(f"Received TEE evidence: {tee_evidence}")
-    logger.debug(f"Received Policy ID: {policy_id}")
-
-    # Report data binding is required for this route,
-    # create a new route for non-binding use cases if needed in the future
-    report_data_binding = data.get("report-data-binding")
-    if report_data_binding is None:
-        logger.error("Secret request missing report data binding")
-        return jsonify({"error": "Report data binding is required"}), 400
-
-    logger.debug(f"Received report data binding: {report_data_binding}")
-
-    # Optional GPU evidence for Phase 2 - if provided, it will be passed to the vm_verify function
-    gpu_evidence = data.get("gpu-evidence", None)  # Phase 2
-
-    # Get client's wrapping key (RSA public key) from the request
-    # The public key is expected to be in base64 format
-    wrapping_key = data.get("wrapping-key")
-    if not wrapping_key:
-        logger.error("Secret request missing wrapping key")
-        return jsonify({"error": "Client's wrapping key is required"}), 400
-
-    # Decode the public key from base64
-    try:
-        wrapping_key = base64.b64decode(wrapping_key)
-        logger.debug("Successfully decoded wrapping key from base64")
-    except (TypeError, ValueError):
-        logger.error("Failed to decode wrapping key from base64")
-        return jsonify({"error": "Invalid econding format for wrapping key"}), 400
-
-    # Log the public key for debugging
-    logger.debug(f"Received public key: {wrapping_key.hex()}")
-
-    # Validate the public key
-    if not isinstance(wrapping_key, bytes):
-        logger.error("Invalid wrapping key format: not bytes")
-        return jsonify({"error": "Invalid wrapping key format"}), 400
-
-    # Call vm_verify to validate the parameters
-    logger.info(f"Starting TEE verification for type: {tee_type}")
-    is_verified, key_id, verify_error = vm_verify(
-        redis_client,
-        nonce,
-        tee_type,
-        tee_evidence,
-        policy_id,
-        wrapping_key=wrapping_key,
-        report_data_binding=report_data_binding,
-        gpu_evidence=gpu_evidence,  # NEW (for Phase 2)
-    )
-    if not is_verified:
-        logger.error(f"TEE verification failed: {verify_error}")
-        return jsonify({"error": "TEE verification failed"}), 400
-
-    # Retrieve the secret from the KMIP Broker Module
-    logger.info(f"Retrieving secret for key ID: {key_id}")
-    try:
-        secret = kbm_get_secret(kbm_client, key_id, wrapping_key)
-        logger.info("Secret retrieval successful")
-    except ValueError as e:
-        logger.error(f"Secret retrieval failed: {str(e)}")
-        return jsonify({"error": "Secret retrieval failed"}), 404
-
-    # Return the secret
-    logger.info(f"Successfully completed secret request for {request.remote_addr}")
-    return jsonify({"secret_key": secret})
-
-
-# Endpoint to retrieve the version information
-@app.route("/version")
-def version():
-    logger.info(f"Received version request from {request.remote_addr}")
-    auth_response = authenticate_request()
-    if auth_response:
-        return auth_response
-    logger.debug(f"Returning TAS version: {TAS_VERSION}")
-    return jsonify({"version": TAS_VERSION})
-
-
 if __name__ == "__main__":
     # Note: This is a simplified example and should not be used in production
-    # without proper security measures such as HTTPS, nonce expiration, etc.
-    # In a real-world scenario, you would also want to implement
-    # proper error handling and logging to ensure that the service is robust and secure
-    # and to prevent abuse of the nonce generation and validation process.
+    # without proper security measures such as HTTPS, etc.
+
     try:
         logger.info(
             f"Starting TAS server on {app.config.get('SERVER_BIND_HOST', '0.0.0.0')}:{app.config.get('SERVER_PORT', 5000)}"

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -127,6 +127,8 @@ Stored in Flask's config; set directly via env without prefix:
 | TAS_REDIS_PORT | int | `6379` | No | Port number of the Redis server. |
 | TAS_REDIS_PASSWORD | str | `""` | No | Redis AUTH password. When set, TAS authenticates to Redis on connection. Always set via environment variable, never in config files. |
 | TAS_REDIS_PERSISTENCE | bool | `true` | No | When `true`, TAS configures Redis AOF + RDB persistence at startup via `CONFIG SET`. Set to `false` if your Redis is externally managed or you want to use your own `redis.conf` settings. Check `GET /management/status` for runtime persistence state. See [REDIS_PERSISTENCE.md](REDIS_PERSISTENCE.md) for details. |
+| TAS_EPHEMERAL_REDIS_URI | str | `""` | No | Redis URI for an optional ephemeral Redis instance. When set, nonces and rate-limit counters are stored here instead of the primary Redis. Policies always remain on the primary. TAS validates connectivity and Redis version (>= 6.2) at startup. Treated as sensitive — masked in logs. |
+| TAS_EPHEMERAL_REDIS_PASSWORD | str | `""` | No | Optional AUTH password for the ephemeral Redis instance. Use this when you do not want to embed credentials in `TAS_EPHEMERAL_REDIS_URI`. Treated as sensitive — masked in logs. |
 | TAS_PLUGIN_PREFIX | str | `"tas_kbm"` | No | Module name prefix used to discover KBM (Key Broker Module) plugins at startup. Only modules whose name starts with this prefix are loaded. |
 | TAS_KBM_PLUGIN | str | `"tas_kbm_mock"` | No | Exact module name of the KBM plugin to activate. Must match one of the discovered plugins. Controls which key broker backend TAS uses (e.g., mock, KMIP, KMIP-JSON). |
 | TAS_KBM_CONFIG_FILE | str | `"./config/kbm_mock_config.yaml"` | No | Path to the configuration file passed to the selected KBM plugin during initialisation. The format depends on the plugin (e.g., PyKMIP conf, KMIP-JSON YAML). |
@@ -148,11 +150,96 @@ These live under `app.config["TAS"]` as a nested dictionary. Set them in the YAM
 | logging.quiet | bool | `false` | When `true`, forces the log level to `WARNING` regardless of `logging.level`. |
 | logging.cli | bool | `false` | When `true`, enables CLI-friendly log formatting (plain text, no timestamps). |
 
-#### Rate Limits (`TAS.limits.*`)
+#### Rate Limiting
+
+TAS uses [Flask-Limiter](https://flask-limiter.readthedocs.io/) to enforce per-IP rate limits on client routes (`/kb/v0/get_nonce`, `/kb/v0/get_secret`, `/version`). Management routes are **not** rate-limited. The default limit is **200 requests per minute per source IP**.
+
+When a client exceeds the limit, TAS returns `429 Too Many Requests` with a JSON body and a `Retry-After` header. The `tas_agent` already handles 429 responses with exponential backoff.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| limits.max_nonce_per_minute | int | `120` | Maximum number of nonces that can be generated per minute. Requests exceeding this limit are rejected. |
+| RATELIMIT_ENABLED | bool | `true` | Rate limiting toggle switch. Set to `false` to disable all client-route rate limiting. |
+| RATELIMIT_HEADERS_ENABLED | bool | `true` | When `true`, responses include `RateLimit-*` headers showing remaining quota. |
+| RATELIMIT_STRATEGY | str | `"fixed-window"` | Rate limiting strategy. See [Flask-Limiter strategies](https://flask-limiter.readthedocs.io/en/stable/strategies.html). |
+| RATELIMIT_SWALLOW_ERRORS | bool | `true` | When `true`, rate limiting degrades gracefully if Redis is unreachable (requests are allowed through). |
+| RATELIMIT_KEY_PREFIX | str | `"tas_ratelimit:"` | Redis key prefix for rate limit counters. Change if running multiple TAS instances sharing a Redis server. |
+| RATELIMIT_STORAGE_URI | str | *(derived)* | Explicit Redis URI for rate limit counters. When set to a non-empty value, Flask-Limiter uses it unchanged. When absent (or empty/whitespace/null), TAS derives the limiter target: `TAS_EPHEMERAL_REDIS_URI` if configured, otherwise the shared primary Redis connection pool. |
+| TAS_CLIENT_RATE_LIMIT | str | `"200 per minute"` | Rate limit applied to all client routes. Uses [Flask-Limiter rate string syntax](https://flask-limiter.readthedocs.io/en/stable/configuration.html#rate-limit-string-notation) (e.g. `"100 per minute"`, `"5 per second"`). |
+| TAS_TRUST_X_FORWARDED_FOR | bool | `false` | When `true`, TAS uses the first IP from the `X-Forwarded-For` header for rate limiting instead of `request.remote_addr`. Enable this **only** when TAS runs behind a trusted reverse proxy (e.g., Nginx) — otherwise clients can spoof their IP to bypass rate limits. |
+
+`RATELIMIT_*` keys are Flask-Limiter native config and can be set via the config file or Flask env mechanisms. `TAS_CLIENT_RATE_LIMIT` and `TAS_TRUST_X_FORWARDED_FOR` are TAS-specific keys and can be overridden via environment variable.
+
+#### Redis routing
+
+By default, TAS uses a single Redis instance for policies, nonces, cert/collateral caching, and rate-limit counters. Set `TAS_EPHEMERAL_REDIS_URI` to route nonces and rate-limit counters to a separate Redis instance while keeping policies on the primary.
+
+**Precedence for rate-limit storage:**
+
+1. `RATELIMIT_STORAGE_URI` (explicit user override) — used unchanged if non-empty.
+2. `TAS_EPHEMERAL_REDIS_URI` — used when no explicit override is set.
+3. Shared primary pool — used when neither is configured.
+
+**Deployment examples:**
+
+```yaml
+# Single Redis (default) — everything shares one instance
+TAS_REDIS_HOST: redis.internal
+TAS_REDIS_PORT: 6379
+```
+
+```yaml
+# Primary + ephemeral — policies on primary, nonces and rate limiting on ephemeral
+TAS_REDIS_HOST: redis-persistent.internal
+TAS_EPHEMERAL_REDIS_URI: "redis://redis-ephemeral.internal:6379/0"
+```
+
+```yaml
+# Explicit rate-limit override — bypasses TAS routing for Flask-Limiter only
+TAS_REDIS_HOST: redis-persistent.internal
+TAS_EPHEMERAL_REDIS_URI: "redis://redis-ephemeral.internal:6379/0"
+RATELIMIT_STORAGE_URI: "redis://redis-ratelimit.internal:6379/0"
+```
+
+**Why separate Redis instances?**
+
+Nonces and rate-limit counters are short-lived, write-heavy, and disposable —
+the opposite of policies. On a single Redis instance with AOF persistence
+enabled, nonce SET/GETDEL traffic and rate-limit counter increments add
+avoidable AOF growth and contribute to `fsync` and rewrite load even though
+the data expires in seconds to minutes. At scale this creates three problems:
+
+| Workloads | Attestation interval | Nonce writes/sec | Wasted AOF entries/day |
+|-----------|----------------------|------------------|------------------------|
+| 1,000 | 5 min | ~7 | ~600 K |
+| 5,000 | 5 min | ~33 | ~2.9 M |
+| 10,000 | 5 min | ~67 | ~5.8 M |
+
+Rate-limit counters add to the total: every client request increments at least
+one counter key and, under the default `fixed-window` strategy, each window
+creates a new key that expires shortly after. The combined ephemeral write
+volume (nonces + rate-limit metadata) is what drives the concerns below.
+
+1. **SSD write endurance** — These unnecessary writes may become an issue on SSDs,
+   which wear out over time. Each nonce op is roughly ~100 bytes in the AOF, and
+   each rate-limit counter increment is comparable. At 10 K workloads the
+   combined nonce and rate-limit traffic can exceed ~578 MB/day of raw AOF
+   writes, and SSD internal write amplification can turn that into materially
+   higher NAND wear for data that is intentionally ephemeral.
+
+2. **Tail-latency isolation** — When Redis persistence is enabled, AOF `fsync`
+   and rewrite activity can introduce tail-end latency spikes. Splitting nonces
+   and rate-limit counters onto an ephemeral instance (`appendonly no`,
+   `save ""`) prevents short-lived ephemeral traffic from being coupled to
+   persistent policy-store I/O and keeps nonce and rate-limit latency more
+   predictable.
+
+3. **Failure-domain separation** — If the primary Redis needs a failover or is
+   busy with an RDB save, nonce generation and rate limiting continue
+   uninterrupted on the ephemeral instance.
+
+For small deployments (tens of workloads) a single instance is fine. Consider
+splitting once sustained nonce and rate-limit write volume makes SSD wear or
+fsync latency a concern.
 
 ### Validation at startup
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ cryptography>=40.0.0
 rfc8785>=0.1.0
 pycryptodome>=3.15.0
 Flask>=3.0.0
+Flask-Limiter[redis]>=3.0.0
 gunicorn>=20.0.0
 redis>=4.0.0
 hexdump>=3.0

--- a/tas/client_routes.py
+++ b/tas/client_routes.py
@@ -1,0 +1,188 @@
+#
+# TEE Attestation Service - Client Routes
+#
+# Copyright 2026 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# This file is part of the TEE Attestation Service.
+#
+# This module provides the client API blueprint for attestation operations.
+# Routes: /kb/v0/get_nonce, /kb/v0/get_secret, /version
+#
+
+import base64
+import secrets
+
+from flask import Blueprint, current_app, jsonify, request
+
+from .auth import authenticate_request
+from .nonce import store_nonce, validate_nonce
+from .tas_logging import get_logger
+from .tas_vm import vm_verify
+
+logger = get_logger(__name__)
+
+client_bp = Blueprint("client", __name__)
+
+
+def get_redis():
+    """Retrieve the primary Redis client from the application extensions."""
+    return current_app.extensions["redis"]
+
+
+def get_nonce_redis():
+    """Retrieve the Redis client for nonce operations.
+
+    Returns the ephemeral Redis client when configured, otherwise the primary.
+    """
+    return current_app.extensions.get(
+        "redis_ephemeral", current_app.extensions["redis"]
+    )
+
+
+@client_bp.route("/kb/v0/get_nonce", methods=["GET"])
+def get_nonce():
+    logger.info(f"Received nonce request from {request.remote_addr}")
+    auth_response = authenticate_request()
+    if auth_response:
+        return auth_response
+
+    # Generate a random nonce
+    nonce = secrets.token_hex(32)  # Generate a 64-character nonce
+    logger.debug(f"Generated nonce: {nonce}")
+
+    # Store the nonce in Redis
+    redis_client = get_nonce_redis()
+    expiration = current_app.config["TAS_NONCE_EXPIRATION_SECONDS"]
+    store_nonce(redis_client, nonce, expiration)
+    logger.info("Nonce generated and stored successfully")
+
+    return jsonify({"nonce": nonce})
+
+
+@client_bp.route("/kb/v0/get_secret", methods=["POST"])
+def get_secret():
+    logger.info(f"Received secret request from {request.remote_addr}")
+    auth_response = authenticate_request()
+    if auth_response:
+        return auth_response
+
+    # Get the JSON data from the request
+    data = request.get_json()
+    if not data:
+        logger.error("Secret request missing JSON body")
+        return jsonify({"error": "Request body is required"}), 400
+
+    # Validate the "tee-type" field early
+    tee_type = data.get("tee-type")
+    if tee_type not in ["amd-sev-snp", "intel-tdx"]:
+        logger.error(f"Invalid TEE type received: {tee_type}")
+        return jsonify({"error": "Invalid or missing 'tee-type' field"}), 400
+
+    # Validate the "nonce" field
+    nonce = data.get("nonce")
+    if not nonce:
+        logger.error("Secret request missing nonce field")
+        return jsonify({"error": "Nonce is required"}), 400
+
+    nonce = str(nonce).strip('"')
+    nonce_client = get_nonce_redis()
+    is_valid, error_message = validate_nonce(nonce_client, nonce)
+    if not is_valid:
+        logger.error(f"Nonce validation failed: {error_message}")
+        return jsonify({"error": error_message}), 401
+
+    # Validate the "tee-evidence" field
+    tee_evidence = data.get("tee-evidence")
+    if not tee_evidence:
+        logger.error("Secret request missing TEE evidence")
+        return jsonify({"error": "TEE evidence is required"}), 400
+
+    # Validate the "policy-id" field
+    policy_id = data.get("policy-id")
+    if not policy_id:
+        logger.error("Secret request missing policy ID")
+        return jsonify({"error": "Policy ID is required"}), 400
+
+    # Log the fields for debugging
+    logger.debug(f"Received TEE evidence: {tee_evidence}")
+    logger.debug(f"Received Policy ID: {policy_id}")
+
+    # Report data binding is required for this route,
+    # create a new route for non-binding use cases if needed in the future
+    report_data_binding = data.get("report-data-binding")
+    if report_data_binding is None:
+        logger.error("Secret request missing report data binding")
+        return jsonify({"error": "Report data binding is required"}), 400
+
+    logger.debug(f"Received report data binding: {report_data_binding}")
+
+    # Optional GPU evidence for Phase 2 - if provided, it will be passed to the vm_verify function
+    gpu_evidence = data.get("gpu-evidence", None)  # Phase 2
+
+    # Get client's wrapping key (RSA public key) from the request
+    # The public key is expected to be in base64 format
+    wrapping_key = data.get("wrapping-key")
+    if not wrapping_key:
+        logger.error("Secret request missing wrapping key")
+        return jsonify({"error": "Client's wrapping key is required"}), 400
+
+    # Decode the public key from base64
+    try:
+        wrapping_key = base64.b64decode(wrapping_key)
+        logger.debug("Successfully decoded wrapping key from base64")
+    except (TypeError, ValueError):
+        logger.error("Failed to decode wrapping key from base64")
+        return jsonify({"error": "Invalid encoding format for wrapping key"}), 400
+
+    # Log the public key for debugging
+    logger.debug(f"Received public key: {wrapping_key.hex()}")
+
+    # Validate the public key
+    if not isinstance(wrapping_key, bytes):
+        logger.error("Invalid wrapping key format: not bytes")
+        return jsonify({"error": "Invalid wrapping key format"}), 400
+
+    # Call vm_verify to validate the parameters — always uses primary Redis
+    # for policy lookup, cert caching, and collateral caching
+    redis_client = get_redis()
+    logger.info(f"Starting TEE verification for type: {tee_type}")
+    is_verified, key_id, verify_error = vm_verify(
+        redis_client,
+        nonce,
+        tee_type,
+        tee_evidence,
+        policy_id,
+        wrapping_key=wrapping_key,
+        report_data_binding=report_data_binding,
+        gpu_evidence=gpu_evidence,  # NEW (for Phase 2)
+    )
+    if not is_verified:
+        logger.error(f"TEE verification failed: {verify_error}")
+        return jsonify({"error": "TEE verification failed"}), 400
+
+    # Retrieve the secret from the KMIP Broker Module
+    logger.info(f"Retrieving secret for key ID: {key_id}")
+    kbm_get_secret = current_app.extensions["kbm_get_secret"]
+    kbm_client = current_app.extensions["kbm_client"]
+    try:
+        secret = kbm_get_secret(kbm_client, key_id, wrapping_key)
+        logger.info("Secret retrieval successful")
+    except ValueError as e:
+        logger.error(f"Secret retrieval failed: {str(e)}")
+        return jsonify({"error": "Secret retrieval failed"}), 404
+
+    # Return the secret
+    logger.info(f"Successfully completed secret request for {request.remote_addr}")
+    return jsonify({"secret_key": secret})
+
+
+@client_bp.route("/version")
+def version():
+    logger.info(f"Received version request from {request.remote_addr}")
+    auth_response = authenticate_request()
+    if auth_response:
+        return auth_response
+    tas_version = current_app.config["TAS_VERSION"]
+    logger.debug(f"Returning TAS version: {tas_version}")
+    return jsonify({"version": tas_version})

--- a/tas/config.py
+++ b/tas/config.py
@@ -40,10 +40,23 @@ class BaseConfig:
     TAS_REDIS_PORT = 6379
     TAS_REDIS_PASSWORD = ""
     TAS_REDIS_PERSISTENCE = True
+    TAS_EPHEMERAL_REDIS_URI = ""
+    TAS_EPHEMERAL_REDIS_PASSWORD = ""
     TAS_PLUGIN_PREFIX = "tas_kbm"
     TAS_KBM_CONFIG_FILE = "./config/kbm_mock_config.yaml"
     TAS_KBM_PLUGIN = "tas_kbm_mock"
     TAS_EXTRA_PLUGIN_DIR = None
+
+    # Rate limiting (Flask-Limiter native keys)
+    RATELIMIT_ENABLED = True
+    RATELIMIT_HEADERS_ENABLED = True
+    RATELIMIT_STRATEGY = "fixed-window"
+    RATELIMIT_SWALLOW_ERRORS = True
+    RATELIMIT_KEY_PREFIX = "tas_ratelimit:"
+
+    # Proxy-aware IP keying
+    TAS_CLIENT_RATE_LIMIT = "200 per minute"
+    TAS_TRUST_X_FORWARDED_FOR = False
 
     def __init__(self):
         logger.debug("Initializing BaseConfig with default TAS settings")

--- a/tas/config_loader.py
+++ b/tas/config_loader.py
@@ -41,6 +41,10 @@ KNOWN_TAS_KEYS = {
     "TAS_KBM_PLUGIN",
     "TAS_ENFORCE_SIGNED_POLICIES",
     "TAS_EXTRA_PLUGIN_DIR",
+    "TAS_CLIENT_RATE_LIMIT",
+    "TAS_TRUST_X_FORWARDED_FOR",
+    "TAS_EPHEMERAL_REDIS_URI",
+    "TAS_EPHEMERAL_REDIS_PASSWORD",
 }
 
 
@@ -203,7 +207,13 @@ def _load_trusted_keys(path: str):
 
 def apply_tas_env_overrides(app):
     # Direct overrides (exact match)
-    _SENSITIVE_KEYS = {"TAS_REDIS_PASSWORD", "TAS_API_KEY", "TAS_MANAGEMENT_API_KEY"}
+    _SENSITIVE_KEYS = {
+        "TAS_REDIS_PASSWORD",
+        "TAS_API_KEY",
+        "TAS_MANAGEMENT_API_KEY",
+        "TAS_EPHEMERAL_REDIS_URI",
+        "TAS_EPHEMERAL_REDIS_PASSWORD",
+    }
     direct_overrides = []
     for key in KNOWN_TAS_KEYS:
         if key in os.environ:
@@ -347,3 +357,23 @@ def load_configuration(app):
         app.config["TAS_TRUSTED_KEYS"] = trusted_keys
 
     logger.info("Configuration loading completed successfully")
+
+
+def resolve_ratelimit_storage(app_config, primary_client):
+    """Return (storage_uri, storage_options, mode_label) for Flask-Limiter."""
+    # Check for explicit user override — handles None (YAML null), empty, whitespace
+    user_uri = app_config.get("RATELIMIT_STORAGE_URI")
+    if user_uri is not None and str(user_uri).strip():
+        return str(user_uri).strip(), {}, "user override"
+
+    # Derive from ephemeral Redis if configured
+    ephemeral_uri = (app_config.get("TAS_EPHEMERAL_REDIS_URI") or "").strip()
+    if ephemeral_uri:
+        return ephemeral_uri, {}, "derived ephemeral"
+
+    # Fall back to sharing the primary Redis connection pool
+    return (
+        "redis://",
+        {"connection_pool": primary_client.connection_pool},
+        "shared primary pool",
+    )

--- a/tas/rate_limiter.py
+++ b/tas/rate_limiter.py
@@ -1,0 +1,54 @@
+#
+# TEE Attestation Service
+#
+# Copyright 2026 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# This file is part of the TEE Attestation Service.
+# See LICENSE file for details.
+#
+# This module sets up the Flask-Limiter extension for rate limiting client requests.
+
+import logging
+
+from flask import jsonify, request
+from flask_limiter import Limiter
+
+logger = logging.getLogger(__name__)
+
+
+def setup_rate_limiter(app, client_blueprint, storage_uri, storage_options):
+    """Encapsulates limiter construction and error handler registration."""
+
+    def _get_client_ip():
+        if app.config.get("TAS_TRUST_X_FORWARDED_FOR"):
+            return request.access_route[0]
+        return request.remote_addr
+
+    limiter = Limiter(
+        app=app,
+        key_func=_get_client_ip,
+        storage_uri=storage_uri,
+        storage_options=storage_options,
+        enabled=app.config.get("RATELIMIT_ENABLED", True),
+        strategy=app.config.get("RATELIMIT_STRATEGY", "fixed-window"),
+        headers_enabled=app.config.get("RATELIMIT_HEADERS_ENABLED", True),
+        swallow_errors=app.config.get("RATELIMIT_SWALLOW_ERRORS", True),
+        key_prefix=app.config.get("RATELIMIT_KEY_PREFIX", "tas_ratelimit:"),
+    )
+
+    client_rate_limit = app.config.get("TAS_CLIENT_RATE_LIMIT", "200 per minute")
+    limiter.limit(client_rate_limit)(client_blueprint)
+
+    @app.errorhandler(429)
+    def ratelimit_handler(e):
+        response = jsonify(
+            {"error": "rate_limit_exceeded", "message": str(e.description)}
+        )
+        response.status_code = 429
+        retry_after = e.response.headers.get("Retry-After") if e.response else None
+        if retry_after:
+            response.headers["Retry-After"] = retry_after
+        return response
+
+    return limiter

--- a/tests/test_nonce_validation.py
+++ b/tests/test_nonce_validation.py
@@ -7,6 +7,8 @@
 # This file is part of the TEE Attestation Service.
 #
 
+import base64
+
 import pytest
 
 from tas.nonce import check_redis_version, store_nonce, validate_nonce
@@ -116,3 +118,97 @@ class TestRedisVersionCheck:
         r.info = lambda section=None: {"redis_version": "5.0.14"}
         with pytest.raises(RuntimeError, match="requires Redis 6.2"):
             check_redis_version(r)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Tests: Nonce Redis client routing (get_nonce_redis / get_redis split)
+# ──────────────────────────────────────────────────────────────────────────
+
+from unittest.mock import MagicMock, patch
+
+from flask import Flask
+
+from tas.client_routes import client_bp, get_nonce_redis, get_redis
+
+
+def _make_app(with_ephemeral=False):
+    """Create a minimal Flask app with optional ephemeral Redis extension."""
+    app = Flask(__name__)
+    app.config.update(
+        TESTING=True,
+        TAS_API_KEY="k" * 64,
+        TAS_MANAGEMENT_API_KEY="m" * 64,
+        TAS_API_KEY_MIN_LENGTH=64,
+        TAS_MANAGEMENT_API_KEY_MIN_LENGTH=64,
+        TAS_VERSION="0.1.0-test",
+        TAS_NONCE_EXPIRATION_SECONDS=120,
+    )
+    primary = MagicMock(name="primary_redis")
+    app.extensions["redis"] = primary
+    if with_ephemeral:
+        ephemeral = MagicMock(name="ephemeral_redis")
+        app.extensions["redis_ephemeral"] = ephemeral
+    app.register_blueprint(client_bp)
+    return app
+
+
+class TestNonceRedisRouting:
+    """Verify get_nonce_redis returns the correct client."""
+
+    def test_returns_ephemeral_when_configured(self):
+        app = _make_app(with_ephemeral=True)
+        with app.app_context():
+            result = get_nonce_redis()
+            assert result is app.extensions["redis_ephemeral"]
+
+    def test_returns_primary_when_no_ephemeral(self):
+        app = _make_app(with_ephemeral=False)
+        with app.app_context():
+            result = get_nonce_redis()
+            assert result is app.extensions["redis"]
+
+    def test_get_redis_always_returns_primary(self):
+        app = _make_app(with_ephemeral=True)
+        with app.app_context():
+            result = get_redis()
+            assert result is app.extensions["redis"]
+
+    def test_primary_extension_unchanged_with_ephemeral(self):
+        app = _make_app(with_ephemeral=True)
+        with app.app_context():
+            primary = get_redis()
+            nonce = get_nonce_redis()
+            assert primary is not nonce
+            assert primary is app.extensions["redis"]
+
+    def test_get_secret_uses_ephemeral_for_nonce_and_primary_for_vm_verify(self):
+        app = _make_app(with_ephemeral=True)
+        app.extensions["kbm_client"] = MagicMock(name="kbm_client")
+        app.extensions["kbm_get_secret"] = MagicMock(return_value="wrapped-secret")
+
+        request_body = {
+            "tee-type": "amd-sev-snp",
+            "nonce": "abc123",
+            "tee-evidence": "evidence",
+            "policy-id": "policy:test",
+            "report-data-binding": True,
+            "wrapping-key": base64.b64encode(b"pk").decode("ascii"),
+        }
+
+        with (
+            patch("tas.client_routes.authenticate_request", return_value=None),
+            patch(
+                "tas.client_routes.validate_nonce", return_value=(True, None)
+            ) as validate_nonce_mock,
+            patch(
+                "tas.client_routes.vm_verify", return_value=(True, "key-id", None)
+            ) as vm_verify_mock,
+        ):
+            with app.test_client() as client:
+                response = client.post("/kb/v0/get_secret", json=request_body)
+
+        assert response.status_code == 200
+        assert (
+            validate_nonce_mock.call_args.args[0] is app.extensions["redis_ephemeral"]
+        )
+        assert vm_verify_mock.call_args.args[0] is app.extensions["redis"]

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,278 @@
+#
+# TEE Attestation Service - Tests for Rate Limiting
+#
+# Copyright 2026 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# This file is part of the TEE Attestation Service.
+# See LICENSE file for details.
+#
+# This module contains tests for the rate limiting functionality.
+
+
+import pytest
+from flask import Flask
+
+from tas.auth import init_client_auth, init_management_auth
+from tas.client_routes import client_bp
+from tas.config_loader import resolve_ratelimit_storage
+from tas.management_routes import management_bp
+from tas.rate_limiter import setup_rate_limiter
+
+
+def _build_app(extra_config=None):
+    """Create a minimal Flask app with client + management blueprints and
+    rate limiting configured with memory:// storage for testing."""
+    app = Flask(__name__)
+    app.config.update(
+        TESTING=True,
+        TAS_API_KEY="k" * 64,
+        TAS_MANAGEMENT_API_KEY="m" * 64,
+        TAS_API_KEY_MIN_LENGTH=64,
+        TAS_MANAGEMENT_API_KEY_MIN_LENGTH=64,
+        TAS_VERSION="0.1.0-test",
+        TAS_NONCE_EXPIRATION_SECONDS=120,
+        TAS_CLIENT_RATE_LIMIT="3 per minute",
+        TAS_TRUST_X_FORWARDED_FOR=False,
+        RATELIMIT_ENABLED=True,
+        RATELIMIT_HEADERS_ENABLED=True,
+        RATELIMIT_STRATEGY="fixed-window",
+        RATELIMIT_SWALLOW_ERRORS=False,
+        RATELIMIT_KEY_PREFIX="test_ratelimit:",
+        RATELIMIT_STORAGE_URI="memory://",
+    )
+    if extra_config:
+        app.config.update(extra_config)
+
+    init_client_auth(app)
+    init_management_auth(app)
+
+    setup_rate_limiter(app, client_bp, app.config["RATELIMIT_STORAGE_URI"], {})
+
+    app.register_blueprint(management_bp)
+    app.register_blueprint(client_bp)
+
+    return app
+
+
+# ── Test: Client route exceeds limit -> 429 ────────────────────────
+
+
+class TestClientRouteRateLimiting:
+    def test_client_route_returns_429_after_limit(self):
+        """Hitting /version beyond the limit should return 429 JSON."""
+        app = _build_app()
+        headers = {"X-API-KEY": "k" * 64}
+        with app.test_client() as client:
+            for _ in range(3):
+                resp = client.get("/version", headers=headers)
+                assert resp.status_code == 200
+
+            resp = client.get("/version", headers=headers)
+            assert resp.status_code == 429
+            data = resp.get_json()
+            assert data["error"] == "rate_limit_exceeded"
+
+
+# ── Test: Management route is unaffected ────────────────────────────
+
+
+class TestManagementRouteUnlimited:
+    def test_management_route_not_rate_limited(self):
+        """Management routes should not have a rate limit."""
+        app = _build_app()
+        # Stub Redis for management routes
+        from unittest.mock import MagicMock
+
+        mock_redis = MagicMock()
+        mock_redis.keys.return_value = []
+        app.extensions["redis"] = mock_redis
+
+        mgmt_headers = {"X-MANAGEMENT-API-KEY": "m" * 64}
+        with app.test_client() as client:
+            # Hit management route more than 3 times (client limit)
+            for i in range(5):
+                resp = client.get("/management/policy/v0/list", headers=mgmt_headers)
+                assert (
+                    resp.status_code == 200
+                ), f"Request {i + 1} to management route was rate limited"
+
+
+# ── Test: Rate limit headers present ───────────────────────────────
+
+
+class TestRateLimitHeaders:
+    def test_ratelimit_headers_present(self):
+        """RateLimit-* headers should be present when enabled."""
+        app = _build_app()
+        headers = {"X-API-KEY": "k" * 64}
+        with app.test_client() as client:
+            resp = client.get("/version", headers=headers)
+            assert resp.status_code == 200
+            # Flask-Limiter adds these headers
+            assert (
+                "RateLimit-Limit" in resp.headers or "X-RateLimit-Limit" in resp.headers
+            )
+
+
+# ── Test: Kill switch disables limiting ────────────────────────────
+
+
+class TestKillSwitch:
+    def test_ratelimit_disabled(self):
+        """When RATELIMIT_ENABLED=False, no rate limiting should occur."""
+        app = _build_app(extra_config={"RATELIMIT_ENABLED": False})
+        headers = {"X-API-KEY": "k" * 64}
+        with app.test_client() as client:
+            for _ in range(10):
+                resp = client.get("/version", headers=headers)
+                assert resp.status_code == 200
+
+
+# ── Test: Proxy-aware keying ───────────────────────────────────────
+
+
+class TestProxyAwareKeying:
+    def test_x_forwarded_for_keying(self):
+        """When TAS_TRUST_X_FORWARDED_FOR=True, different X-Forwarded-For
+        values should have independent rate limit buckets."""
+        app = _build_app(extra_config={"TAS_TRUST_X_FORWARDED_FOR": True})
+        headers = {"X-API-KEY": "k" * 64}
+        with app.test_client() as client:
+            # Exhaust limit for IP 10.0.0.1
+            for _ in range(3):
+                resp = client.get(
+                    "/version",
+                    headers={**headers, "X-Forwarded-For": "10.0.0.1"},
+                )
+                assert resp.status_code == 200
+
+            # 4th request from 10.0.0.1 should be limited
+            resp = client.get(
+                "/version",
+                headers={**headers, "X-Forwarded-For": "10.0.0.1"},
+            )
+            assert resp.status_code == 429
+
+            # Request from different IP should still succeed
+            resp = client.get(
+                "/version",
+                headers={**headers, "X-Forwarded-For": "10.0.0.2"},
+            )
+            assert resp.status_code == 200
+
+
+# ── Test: Dedicated storage URI override ──────────────────────────
+
+
+class TestStorageUriOverride:
+    def test_explicit_storage_uri_used(self):
+        """When RATELIMIT_STORAGE_URI is set, limiter uses it instead of
+        reusing the nonce/policy Redis connection."""
+        app = _build_app(extra_config={"RATELIMIT_STORAGE_URI": "memory://dedicated"})
+        with app.test_client() as client:
+            # Should still work — limiter honours the explicit URI
+            resp = client.get("/version", headers={"X-API-KEY": "k" * 64})
+            assert resp.status_code == 200
+
+
+# ── Tests: Ratelimit storage resolution precedence ─────────────────
+
+
+class TestResolveRatelimitStorage:
+    """Test _resolve_ratelimit_storage three-state precedence."""
+
+    def _resolve(self, app_config, primary_client=None):
+        """Load and execute the production helper from app.py."""
+        from unittest.mock import MagicMock
+
+        if primary_client is None:
+            primary_client = MagicMock()
+            primary_client.connection_pool = MagicMock()
+
+        return resolve_ratelimit_storage(app_config, primary_client)
+
+    def test_user_override_wins_over_ephemeral(self):
+        """Explicit RATELIMIT_STORAGE_URI wins even when TAS_EPHEMERAL_REDIS_URI is set."""
+        uri, opts, mode = self._resolve(
+            {
+                "RATELIMIT_STORAGE_URI": "redis://dedicated:6380/0",
+                "TAS_EPHEMERAL_REDIS_URI": "redis://ephemeral:6381/0",
+            }
+        )
+        assert uri == "redis://dedicated:6380/0"
+        assert opts == {}
+        assert mode == "user override"
+
+    def test_ephemeral_used_when_no_user_override(self):
+        """TAS_EPHEMERAL_REDIS_URI used when RATELIMIT_STORAGE_URI is absent."""
+        uri, opts, mode = self._resolve(
+            {"TAS_EPHEMERAL_REDIS_URI": "redis://ephemeral:6381/0"}
+        )
+        assert uri == "redis://ephemeral:6381/0"
+        assert opts == {}
+        assert mode == "derived ephemeral"
+
+    def test_primary_pool_when_nothing_set(self):
+        """Falls back to shared primary pool when neither is set."""
+        from unittest.mock import MagicMock
+
+        mock_client = MagicMock()
+        uri, opts, mode = self._resolve({}, primary_client=mock_client)
+        assert uri == "redis://"
+        assert opts["connection_pool"] is mock_client.connection_pool
+        assert mode == "shared primary pool"
+
+    def test_empty_ratelimit_uri_does_not_suppress_fallback(self):
+        """Empty string RATELIMIT_STORAGE_URI should not suppress ephemeral fallback."""
+        uri, opts, mode = self._resolve(
+            {
+                "RATELIMIT_STORAGE_URI": "",
+                "TAS_EPHEMERAL_REDIS_URI": "redis://ephemeral:6381/0",
+            }
+        )
+        assert uri == "redis://ephemeral:6381/0"
+        assert mode == "derived ephemeral"
+
+    def test_whitespace_ratelimit_uri_does_not_suppress_fallback(self):
+        """Whitespace-only RATELIMIT_STORAGE_URI should not suppress fallback."""
+        uri, opts, mode = self._resolve(
+            {
+                "RATELIMIT_STORAGE_URI": "   ",
+                "TAS_EPHEMERAL_REDIS_URI": "redis://ephemeral:6381/0",
+            }
+        )
+        assert uri == "redis://ephemeral:6381/0"
+        assert mode == "derived ephemeral"
+
+    def test_none_ratelimit_uri_does_not_suppress_fallback(self):
+        """None RATELIMIT_STORAGE_URI (YAML null) should not suppress fallback."""
+        uri, opts, mode = self._resolve(
+            {
+                "RATELIMIT_STORAGE_URI": None,
+                "TAS_EPHEMERAL_REDIS_URI": "redis://ephemeral:6381/0",
+            }
+        )
+        assert uri == "redis://ephemeral:6381/0"
+        assert mode == "derived ephemeral"
+
+    def test_empty_ephemeral_falls_to_primary(self):
+        """Empty TAS_EPHEMERAL_REDIS_URI should fall to shared primary pool."""
+        from unittest.mock import MagicMock
+
+        mock_client = MagicMock()
+        uri, opts, mode = self._resolve(
+            {"TAS_EPHEMERAL_REDIS_URI": ""}, primary_client=mock_client
+        )
+        assert uri == "redis://"
+        assert mode == "shared primary pool"
+
+    def test_shared_primary_returns_connection_pool_storage_options(self):
+        """Shared-primary mode must provide storage_options with the primary pool."""
+        from unittest.mock import MagicMock
+
+        mock_client = MagicMock()
+        uri, opts, mode = self._resolve({}, primary_client=mock_client)
+        assert uri == "redis://"
+        assert opts == {"connection_pool": mock_client.connection_pool}
+        assert mode == "shared primary pool"


### PR DESCRIPTION
Implement per-IP rate limiting on client-facing endpoints using Flask-Limiter with Redis backend. Management routes are unaffected.

- Extract client routes into tas/client_routes.py blueprint
- Initialize Flask-Limiter at blueprint level (200 req/min default)
- Synthesize Redis storage URI from existing TAS_REDIS_* config
- Add proxy-aware key function with TAS_TRUST_X_FORWARDED_FOR toggle
- Return JSON 429 responses with Retry-After header
- Add RATELIMIT_ENABLED switch and related config defaults
- Add rate limiter tests
- Update docs/CONFIG.md with rate limiting configuration reference