### PR TITLE
Remote attestation with NRAS using nvidia_pytools

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -61,6 +61,8 @@ jobs:
           cd sev_pytools && pip install . && cd ..
           git clone https://github.com/TEE-Attestation/tdx_pytools.git
           cd tdx_pytools && pip install . && cd ..
+          git clone https://github.com/TEE-Attestation/nvidia_pytools.git
+          cd nvidia_pytools && pip install . && cd ..
           pip install -r requirements.txt
           pip install pytest pytest-cov
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ TAS is a simple attestation service that verifies attestation evidence generated
 
 TAS provides:
 - **TEE Attestation**: Validates AMD SEV-SNP and Intel TDX attestation evidence
+- **GPU Attestation**: Optional NVIDIA GPU attestation (via NRAS) cryptographically bound to the CPU TEE
 - **Key Management**: Secure key retrieval with cryptographic nonce validation
 - **Policy Management**: Store and validate security policies for attestation
 - **Pluggable Architecture**: Support for multiple Key Broker Modules (KBM)
@@ -48,6 +49,11 @@ pip install .
 cd ..
 git clone https://github.com/TEE-Attestation/tdx_pytools.git
 cd tdx_pytools
+pip install .
+cd ..
+# Optional: install nvidia_pytools for NVIDIA GPU attestation
+git clone https://github.com/TEE-Attestation/nvidia_pytools.git
+cd nvidia_pytools
 pip install .
 cd ..
 pip install -r requirements.txt
@@ -102,6 +108,7 @@ redis-cli ping
 
 - **AMD SEV-SNP**: Full attestation support
 - **Intel TDX**: Full attestation support  
+- **NVIDIA GPU**: Optional GPU attestation via the NVIDIA Remote Attestation Service (NRAS), bound to AMD SEV-SNP / Intel TDX evidence (requires `nvidia_pytools`)
 
 ## Installation
 
@@ -132,6 +139,12 @@ cd ..
 # Install tdx_pytools (required for Intel TDX support)
 git clone https://github.com/TEE-Attestation/tdx_pytools.git
 cd tdx_pytools
+pip install .
+cd ..
+
+# Install nvidia_pytools (optional, required only for NVIDIA GPU attestation)
+git clone https://github.com/TEE-Attestation/nvidia_pytools.git
+cd nvidia_pytools
 pip install .
 cd ..
 ```

--- a/app.py
+++ b/app.py
@@ -49,7 +49,7 @@ if log_config:
     log_file = log_config.get("file", None)
     verbose = log_config.get("verbose", False)
     quiet = log_config.get("quiet", False)
-    cli = log_config.get("cli", False)
+    cli = log_config.get("cli", True)
 
     # Reconfigure the root "tas" logger with settings from config
     logger = setup_logging(

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -6,6 +6,7 @@ This guide explains how to create, sign, and register security policies in the T
 
 - [Overview](#overview)
 - [Policy Structure](#policy-structure)
+- [Component Policies (GPU Attestation)](#component-policies-gpu-attestation)
 - [Signing Policies](#signing-policies)
 - [Registering Policies](#registering-policies)
 - [Validation Rule Types](#validation-rule-types)
@@ -79,6 +80,7 @@ Policies are stored in Redis and referenced during attestation validation to det
 |-------|------|----------|-------------|
 | `metadata` | object | Yes | Policy metadata (must include `policy_type`, `policy_id`, and `key_id`) |
 | `validation_rules` | object | Yes | Attestation validation criteria |
+| `components` | object | No | Additional attestable component policies (e.g. GPUs). See [Component Policies (GPU Attestation)](#component-policies-gpu-attestation) |
 | `signature` | object | No | Digital signature for integrity |
 
 ### Metadata Fields
@@ -119,6 +121,92 @@ The `tcb` item within `validation_rules` is a special case for TDX policies. It 
       "qe_tcb": "UpToDate"
     },
 ...
+```
+
+## Component Policies (GPU Attestation)
+
+In addition to the CPU TEE rules in `validation_rules`, a policy may carry an
+optional top-level **`components`** section that defines requirements for other
+attestable devices alongside the CPU TEE. Today this is used for **NVIDIA GPU
+attestation**.
+
+The `components` section is **optional** — existing SEV/TDX policies without it
+continue to work unchanged. When present, it is covered by the policy signature
+just like every other top-level field.
+
+### Structure
+
+`components` is keyed by component type (`gpu`). Each component type is keyed by
+the **device type** reported by the agent. NVIDIA GPUs report `gpu-nvidia`:
+
+```json
+{
+  "components": {
+    "gpu": {
+      "gpu-nvidia": {
+        "version": "4.0",
+        "authorization-rules": { ... }
+      }
+    }
+  }
+}
+```
+
+The object under `gpu-nvidia` is an **NVIDIA attestation policy** consumed by
+[`nvidia_pytools`](https://github.com/TEE-Attestation/nvidia_pytools). It
+validates the claims returned by the NVIDIA Remote Attestation Service (NRAS)
+and has two groups of rules:
+
+- **`overall-claims`** — checks applied to the overall NRAS result (e.g. the
+  attestation succeeded overall).
+- **`detached-claims`** — per-GPU checks (measurement result, debug status,
+  secure boot, driver/VBIOS RIM checks, certificate-chain status, etc.).
+
+For each claim, the actual value reported by NRAS must match the value in the
+policy. Nested objects (such as certificate-chain status) are matched field by
+field.
+
+### Example
+
+```json
+{
+  "metadata": {
+    "name": "AMD SEV-SNP + GPU Security Policy",
+    "policy_type": "SEV",
+    "policy_id": "sev-gpu-policy-001",
+    "key_id": "test-key-gpu-1",
+    "version": "1.0"
+  },
+  "validation_rules": {
+    "vmpl": { "exact_match": 0 },
+    "policy": { "debug_allowed": false, "smt_allowed": true }
+  },
+  "components": {
+    "gpu": {
+      "gpu-nvidia": {
+        "version": "4.0",
+        "authorization-rules": {
+          "type": "JWT",
+          "overall-claims": {
+            "x-nvidia-overall-att-result": true,
+            "x-nvidia-ver": "3.0"
+          },
+          "detached-claims": {
+            "measres": "success",
+            "dbgstat": "disabled",
+            "secboot": true,
+            "x-nvidia-gpu-arch-check": true,
+            "x-nvidia-gpu-attestation-report-cert-chain": {
+              "x-nvidia-cert-status": "valid",
+              "x-nvidia-cert-ocsp-status": "good"
+            }
+          }
+        }
+      }
+    }
+  },
+  "signature": { "...": "..." }
+}
 ```
 
 ## Signing Policies

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -80,13 +80,20 @@
             "type": "string",
             "description": "TEE attestation evidence (base64 encoded)"
           },
+          "policy-id": {
+            "type": "string",
+            "description": "Policy identifier for attestation"
+          },
+          "report-data-binding": {
+            "type": "boolean",
+            "description": "When true, the expected CPU report_data is recomputed as SHA-512(nonce || wrapping_key || SHA-512(gpu0_evidence) || ...), binding the wrapping key and any GPU evidence to the CPU TEE. Required for this endpoint."
+          },
           "wrapping-key": {
             "type": "string",
             "description": "Base64-encoded client public key for wrapping"
           },
-          "policy-id": {
-            "type": "string",
-            "description": "Policy identifier for attestation"
+          "component-evidence": {
+            "$ref": "#/components/schemas/ComponentEvidence"
           }
         },
         "required": [
@@ -94,7 +101,45 @@
           "nonce",
           "tee-evidence",
           "policy-id",
+          "report-data-binding",
           "wrapping-key"
+        ]
+      },
+      "ComponentEvidence": {
+        "type": "object",
+        "description": "Optional attestation evidence for additional components (e.g. GPUs) verified alongside the CPU TEE. Keyed by component type.",
+        "properties": {
+          "gpu": {
+            "type": "array",
+            "description": "Per-GPU attestation evidence entries",
+            "items": {
+              "$ref": "#/components/schemas/GpuEvidence"
+            }
+          }
+        }
+      },
+      "GpuEvidence": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "GPU device type",
+            "example": "gpu-nvidia"
+          },
+          "evidence": {
+            "type": "string",
+            "description": "Base64-encoded GPU attestation evidence envelope"
+          },
+          "device-index": {
+            "type": "integer",
+            "description": "GPU device index (used for deterministic ordering of the report_data binding)",
+            "example": 0
+          }
+        },
+        "required": [
+          "type",
+          "evidence",
+          "device-index"
         ]
       },
       "SecretResponse": {
@@ -228,6 +273,9 @@
           "validation_rules": {
             "$ref": "#/components/schemas/PolicyValidationRules"
           },
+          "components": {
+            "$ref": "#/components/schemas/PolicyComponents"
+          },
           "signature": {
             "$ref": "#/components/schemas/PolicySignature"
           }
@@ -236,6 +284,20 @@
           "metadata",
           "validation_rules"
         ]
+      },
+      "PolicyComponents": {
+        "type": "object",
+        "description": "Optional policies for additional attestable components verified alongside the CPU TEE. Keyed by component type (e.g. gpu).",
+        "properties": {
+          "gpu": {
+            "type": "object",
+            "description": "GPU component policy, keyed by GPU device type (e.g. gpu-nvidia). Each value is an NVIDIA attestation policy (with version and authorization-rules) validated by nvidia_pytools against NRAS claims.",
+            "additionalProperties": {
+              "type": "object"
+            }
+          }
+        },
+        "additionalProperties": true
       },
       "VersionResponse": {
         "type": "object",
@@ -514,6 +576,75 @@
         }
       }
     },
+    "/management/policy/v0/get/{policy_id}": {
+      "get": {
+        "tags": [
+          "Policy Management"
+        ],
+        "summary": "Get a security policy",
+        "description": "Retrieves a stored security policy by its policy_id",
+        "security": [
+          {
+            "ManagementApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "policy_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Policy identifier"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Policy retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "policy_key": {
+                      "type": "string",
+                      "description": "Redis storage key"
+                    },
+                    "policy": {
+                      "$ref": "#/components/schemas/PolicyData"
+                    },
+                    "warning": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Policy not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/management/policy/v0/list": {
       "get": {
         "tags": [
@@ -584,111 +715,6 @@
         }
       }
     },
-    "/management/status": {
-      "get": {
-        "tags": [
-          "Management"
-        ],
-        "summary": "Get Redis persistence status",
-        "description": "Returns the current Redis persistence state and whether CONFIG REWRITE succeeded at TAS startup. Requires management API key.",
-        "security": [
-          {
-            "ManagementApiKeyAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Persistence status",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized \u2014 invalid or missing management API key",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/management/policy/v0/get/{policy_id}": {
-      "get": {
-        "tags": [
-          "Policy Management"
-        ],
-        "summary": "Get a security policy",
-        "description": "Retrieves a stored security policy by its policy_id",
-        "security": [
-          {
-            "ManagementApiKeyAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "policy_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Policy identifier"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Policy retrieved successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "policy_key": {
-                      "type": "string",
-                      "description": "Redis storage key"
-                    },
-                    "policy": {
-                      "$ref": "#/components/schemas/PolicyData"
-                    },
-                    "warning": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Policy not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/management/policy/v0/delete/{policy_id}": {
       "delete": {
         "tags": [
@@ -728,6 +754,42 @@
           },
           "404": {
             "description": "Policy not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/management/status": {
+      "get": {
+        "tags": [
+          "Management"
+        ],
+        "summary": "Get Redis persistence status",
+        "description": "Returns the current Redis persistence state and whether CONFIG REWRITE succeeded at TAS startup. Requires management API key.",
+        "security": [
+          {
+            "ManagementApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Persistence status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized \u2014 invalid or missing management API key",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -61,15 +61,54 @@ components:
         policy-id:
           type: string
           description: Policy identifier for attestation
+        report-data-binding:
+          type: boolean
+          description: >-
+            When true, the expected CPU report_data is recomputed as
+            SHA-512(nonce || wrapping_key || SHA-512(gpu0_evidence) || ...),
+            binding the wrapping key and any GPU evidence to the CPU TEE.
+            Required for this endpoint.
         wrapping-key:
           type: string
           description: Base64-encoded client public key for wrapping
+        component-evidence:
+          $ref: '#/components/schemas/ComponentEvidence'
       required:
       - tee-type
       - nonce
       - tee-evidence
       - policy-id
+      - report-data-binding
       - wrapping-key
+    ComponentEvidence:
+      type: object
+      description: >-
+        Optional attestation evidence for additional components (e.g. GPUs)
+        verified alongside the CPU TEE. Keyed by component type.
+      properties:
+        gpu:
+          type: array
+          description: Per-GPU attestation evidence entries
+          items:
+            $ref: '#/components/schemas/GpuEvidence'
+    GpuEvidence:
+      type: object
+      properties:
+        type:
+          type: string
+          description: GPU device type
+          example: gpu-nvidia
+        evidence:
+          type: string
+          description: Base64-encoded GPU attestation evidence envelope
+        device-index:
+          type: integer
+          description: GPU device index (used for deterministic ordering of the report_data binding)
+          example: 0
+      required:
+      - type
+      - evidence
+      - device-index
     SecretResponse:
       type: object
       properties:
@@ -166,11 +205,28 @@ components:
           $ref: '#/components/schemas/PolicyMetadata'
         validation_rules:
           $ref: '#/components/schemas/PolicyValidationRules'
+        components:
+          $ref: '#/components/schemas/PolicyComponents'
         signature:
           $ref: '#/components/schemas/PolicySignature'
       required:
       - metadata
       - validation_rules
+    PolicyComponents:
+      type: object
+      description: >-
+        Optional policies for additional attestable components verified
+        alongside the CPU TEE. Keyed by component type (e.g. gpu).
+      properties:
+        gpu:
+          type: object
+          description: >-
+            GPU component policy, keyed by GPU device type (e.g. gpu-nvidia).
+            Each value is an NVIDIA attestation policy (with version and
+            authorization-rules) validated by nvidia_pytools against NRAS claims.
+          additionalProperties:
+            type: object
+      additionalProperties: true
     VersionResponse:
       type: object
       properties:

--- a/tas/client_routes.py
+++ b/tas/client_routes.py
@@ -117,8 +117,9 @@ def get_secret():
 
     logger.debug(f"Received report data binding: {report_data_binding}")
 
-    # Optional GPU evidence for Phase 2 - if provided, it will be passed to the vm_verify function
-    gpu_evidence = data.get("gpu-evidence", None)  # Phase 2
+    # Optional component evidence
+    component_evidence = data.get("component-evidence", None)
+    gpu_list = component_evidence.get("gpu", None) if component_evidence else None
 
     # Get client's wrapping key (RSA public key) from the request
     # The public key is expected to be in base64 format
@@ -155,7 +156,7 @@ def get_secret():
         policy_id,
         wrapping_key=wrapping_key,
         report_data_binding=report_data_binding,
-        gpu_evidence=gpu_evidence,  # NEW (for Phase 2)
+        gpu_list=gpu_list,
     )
     if not is_verified:
         logger.error(f"TEE verification failed: {verify_error}")

--- a/tas/components/__init__.py
+++ b/tas/components/__init__.py
@@ -1,0 +1,6 @@
+#
+# TEE Attestation Service - Component Verification Modules
+#
+# Copyright 2025 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#

--- a/tas/components/gpu_nvidia.py
+++ b/tas/components/gpu_nvidia.py
@@ -1,0 +1,68 @@
+#
+# TEE Attestation Service - NVIDIA GPU Attestation via nvidia_pytools
+#
+# Copyright 2025 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# TAS component adapter for NVIDIA GPU attestation.
+# Delegates verification to the nvidia_pytools library.
+#
+
+from tas.tas_logging import get_logger, log_function_entry, log_function_exit
+
+logger = get_logger(__name__)
+
+try:
+    import nvidia_pytools
+
+    GPU_PYTOOLS_AVAILABLE = True
+except ImportError:
+    GPU_PYTOOLS_AVAILABLE = False
+    logger.warning(
+        "nvidia_pytools not installed - GPU attestation will not be available. "
+    )
+
+
+def gpu_vm_verify(gpu_tee_type, gpu_evidence_b64, device_index, expected_nonce=None):
+    """
+    Verify a single GPU's attestation evidence via gpu_pytools (NRAS).
+
+    Parameters:
+        gpu_tee_type (str): The type of GPU TEE (e.g., "gpu-nvidia").
+        gpu_evidence_b64 (str): Base64-encoded GPU attestation evidence envelope.
+        device_index (int): The index of the GPU device being verified.
+        expected_nonce (str or None): The nonce TAS issued to the agent. If provided,
+            the evidence envelope's nonce must match (freshness check).
+
+    Returns:
+        is_verified (bool): True if verification is successful, False otherwise.
+        key_id (str or None): The key ID (None for GPU verification).
+        verify_error (str or None): An error message if verification fails, None otherwise.
+    """
+    log_function_entry("gpu_vm_verify")
+
+    if not GPU_PYTOOLS_AVAILABLE:
+        log_function_exit("gpu_vm_verify", "unavailable")
+        return (
+            False,
+            None,
+            (
+                f"GPU {device_index}: nvidia_pytools package is not installed. "
+                "Install with: pip install nvidia_pytools"
+            ),
+        )
+
+    ok, claims, error = nvidia_pytools.verify_gpu_evidence(
+        gpu_evidence_b64=gpu_evidence_b64,
+        device_index=device_index,
+        expected_nonce=expected_nonce,
+    )
+
+    if ok and claims:
+        logger.info(
+            f"GPU {device_index} ({gpu_tee_type}, {claims.hwmodel or 'unknown'}): "
+            "NRAS remote attestation successful"
+        )
+
+    log_function_exit("gpu_vm_verify", "verified" if ok else "failed")
+    return ok, None, error

--- a/tas/components/gpu_nvidia.py
+++ b/tas/components/gpu_nvidia.py
@@ -23,7 +23,9 @@ except ImportError:
     )
 
 
-def gpu_vm_verify(gpu_tee_type, gpu_evidence_b64, device_index, expected_nonce=None):
+def gpu_vm_verify(
+    gpu_tee_type, gpu_evidence_b64, device_index, expected_nonce=None, gpu_policy=None
+):
     """
     Verify a single GPU's attestation evidence via gpu_pytools (NRAS).
 
@@ -33,6 +35,8 @@ def gpu_vm_verify(gpu_tee_type, gpu_evidence_b64, device_index, expected_nonce=N
         device_index (int): The index of the GPU device being verified.
         expected_nonce (str or None): The nonce TAS issued to the agent. If provided,
             the evidence envelope's nonce must match (freshness check).
+        gpu_policy (dict or None): NVIDIA GPU policy dict (with "authorization-rules")
+            to validate claims against. If None, no policy validation is performed.
 
     Returns:
         is_verified (bool): True if verification is successful, False otherwise.
@@ -52,10 +56,24 @@ def gpu_vm_verify(gpu_tee_type, gpu_evidence_b64, device_index, expected_nonce=N
             ),
         )
 
+    # Construct AttestationPolicy if policy rules provided
+    policy = None
+    if gpu_policy:
+        try:
+            policy = nvidia_pytools.AttestationPolicy(policy_data=gpu_policy)
+        except (ValueError, Exception) as e:
+            log_function_exit("gpu_vm_verify", "policy_error")
+            return (
+                False,
+                None,
+                f"GPU {device_index}: invalid GPU policy: {e}",
+            )
+
     ok, claims, error = nvidia_pytools.verify_gpu_evidence(
         gpu_evidence_b64=gpu_evidence_b64,
         device_index=device_index,
         expected_nonce=expected_nonce,
+        policy=policy,
     )
 
     if ok and claims:

--- a/tas/tas_logging.py
+++ b/tas/tas_logging.py
@@ -15,6 +15,7 @@ Logging utilities for TAS (Trusted Attestation Service)
 This module provides centralized logging configuration for both library and CLI usage.
 """
 
+import copy
 import logging
 import sys
 from typing import Optional, Union
@@ -34,7 +35,8 @@ class ColoredFormatter(logging.Formatter):
     }
 
     def format(self, record):
-        # Apply color to the log level name
+        # Apply color to the log level name (on a copy to avoid polluting other handlers)
+        record = copy.copy(record)
         if record.levelname in self.COLORS:
             record.levelname = f"{self.COLORS[record.levelname]}{record.levelname}{self.COLORS['RESET']}"
         return super().format(record)
@@ -131,56 +133,31 @@ def get_logger(name: str = "tas") -> logging.Logger:
     return logging.getLogger(name)
 
 
-def configure_sev_pytools_logging():
-    """Configure sev_pytools logging to use TAS logging settings."""
-    # Create sev_pytools logger as child of tas for inheritance
-    sev_logger = logging.getLogger("tas.sev_pytools")
+def configure_pytools_logging(name: str):
+    """Configure a pytools library's logging to use TAS logging settings."""
+    tas_logger = logging.getLogger(f"tas.{name}")
 
-    # Configure the direct sev_pytools logger to forward to our tas.sev_pytools
-    direct_sev_logger = logging.getLogger("sev_pytools")
-    direct_sev_logger.handlers.clear()
-    direct_sev_logger.propagate = False
-    direct_sev_logger.setLevel(logging.DEBUG)
+    direct_logger = logging.getLogger(name)
+    direct_logger.handlers.clear()
+    direct_logger.propagate = False
+    direct_logger.setLevel(logging.DEBUG)
 
-    # Create handler that forwards messages to our tas.sev_pytools logger
     class TASForwardingHandler(logging.Handler):
         def emit(self, record):
-            sev_logger.handle(record)
+            tas_logger.handle(record)
 
     forwarding_handler = TASForwardingHandler()
     forwarding_handler.setLevel(logging.DEBUG)
-    direct_sev_logger.addHandler(forwarding_handler)
+    direct_logger.addHandler(forwarding_handler)
 
-    logger.debug("Configured sev_pytools logging to inherit TAS settings")
-
-
-def configure_tdx_pytools_logging():
-    """Configure tdx_pytools logging to use TAS logging settings."""
-    # Create tdx_pytools logger as child of tas for inheritance
-    tdx_logger = logging.getLogger("tas.tdx_pytools")
-
-    # Configure the direct tdx_pytools logger to forward to our tas.tdx_pytools
-    direct_tdx_logger = logging.getLogger("tdx_pytools")
-    direct_tdx_logger.handlers.clear()
-    direct_tdx_logger.propagate = False
-    direct_tdx_logger.setLevel(logging.DEBUG)
-
-    # Create handler that forwards messages to our tas.tdx_pytools logger
-    class TASForwardingHandler(logging.Handler):
-        def emit(self, record):
-            tdx_logger.handle(record)
-
-    forwarding_handler = TASForwardingHandler()
-    forwarding_handler.setLevel(logging.DEBUG)
-    direct_tdx_logger.addHandler(forwarding_handler)
-
-    logger.debug("Configured tdx_pytools logging to inherit TAS settings")
+    logger.debug(f"Configured {name} logging to inherit TAS settings")
 
 
 def configure_external_logging():
     """Reconfigure external library logging to reflect TAS logging changes."""
-    configure_sev_pytools_logging()
-    configure_tdx_pytools_logging()
+    configure_pytools_logging("sev_pytools")
+    configure_pytools_logging("tdx_pytools")
+    configure_pytools_logging("nvidia_pytools")
 
 
 # At the moment these functions are called from logger in the logs rather than their parent

--- a/tas/tas_vm.py
+++ b/tas/tas_vm.py
@@ -33,7 +33,11 @@ except ImportError:
     GPU_ATTESTATION_AVAILABLE = False
 
     def gpu_vm_verify(
-        gpu_tee_type, gpu_evidence_b64, device_index, expected_nonce=None
+        gpu_tee_type,
+        gpu_evidence_b64,
+        device_index,
+        expected_nonce=None,
+        gpu_policy=None,
     ):
         return (
             False,
@@ -493,7 +497,7 @@ def sev_vm_verify(
     redis_client: redis.StrictRedis,
     nonce,
     decoded_evidence,
-    policy_id,
+    policy_json,
     expected_report_data=None,
 ):
     """
@@ -503,22 +507,21 @@ def sev_vm_verify(
         redis_client (redis.StrictRedis): Redis client instance for database operations.
         nonce (str): The nonce to verify.
         decoded_evidence (bytes): The decoded TEE evidence.
-        policy_id (str): The policy ID to fetch from Redis.
+        policy_json (dict): The policy JSON, already fetched and verified by the caller.
         expected_report_data (bytes, optional): Pre-computed expected report data.
             When provided, used directly for verification instead of encoding
             the nonce. Typically a SHA-512 digest from vm_verify's binding logic.
 
     Returns:
         is_verified (bool): True if verification is successful, False otherwise.
-        key_id (str or None): The key ID to fetch if the policy used for verification is successful, None otherwise.
         verify_error (str or None): An error message if verification fails, None otherwise.
     """
     log_function_entry("sev_vm_verify")
     if not nonce:
-        return False, None, "Nonce is invalid"
+        return False, "Nonce is invalid"
 
     if not decoded_evidence:
-        return False, None, "Decoded TEE evidence is empty"
+        return False, "Decoded TEE evidence is empty"
 
     report = sev.AttestationReport.unpack(decoded_evidence)
 
@@ -553,13 +556,6 @@ def sev_vm_verify(
             logger.warning("CRL not found in Redis, fetching from AMD key server")
             crl = x509.load_pem_x509_certificate(certs["crl"])
 
-    # Fetch policy from Redis
-    try:
-        policy_json, key_id = get_policy_from_redis(redis_client, policy_id)
-    except ValueError as e:
-        logger.error(f"Policy fetching failed for: '{policy_id}': {e}")
-        return False, None, str(e)
-
     # Use provided report_data or fall back to nonce
     if expected_report_data is not None:
         report_data = expected_report_data
@@ -582,23 +578,23 @@ def sev_vm_verify(
         if verified:
             logger.info("AMD SEV-SNP evidence verification successful")
             log_function_exit("sev_vm_verify", "success")
-            return True, key_id, None
+            return True, None
         else:
             logger.error("AMD SEV-SNP evidence verification failed")
             log_function_exit("sev_vm_verify", "failure")
-            return False, None, "Attestation verification failed"
+            return False, "Attestation verification failed"
 
     except Exception as e:
         logger.error(f"Exception during attestation verification: {e}")
         log_function_exit("sev_vm_verify", "error")
-        return False, None, f"Verification error: {str(e)}"
+        return False, f"Verification error: {str(e)}"
 
 
 def tdx_vm_verify(
     redis_client: redis.StrictRedis,
     nonce,
     decoded_evidence,
-    policy_id,
+    policy_json,
     expected_report_data=None,
 ):
     """
@@ -608,32 +604,25 @@ def tdx_vm_verify(
         redis_client (redis.StrictRedis): Redis client instance for database operations.
         nonce (str): The nonce to verify.
         decoded_evidence (bytes): The decoded TEE evidence.
-        policy_id (str): The policy ID to fetch from Redis.
+        policy_json (dict): The policy JSON, already fetched and verified by the caller.
         expected_report_data (bytes, optional): Pre-computed expected report data.
             When provided, used directly for verification instead of encoding
             the nonce. Typically a SHA-512 digest from vm_verify's binding logic.
 
     Returns:
         is_verified (bool): True if verification is successful, False otherwise.
-        key_id (str or None): The key ID to fetch if the policy used for verification is successful, None otherwise.
         verify_error (str or None): An error message if verification fails, None otherwise.
     """
     log_function_entry("tdx_vm_verify")
 
     if not nonce:
-        return False, None, "Nonce is invalid"
+        return False, "Nonce is invalid"
 
     if not decoded_evidence:
-        return False, None, "Decoded TEE evidence is empty"
+        return False, "Decoded TEE evidence is empty"
 
     quote = tdx.Quote.unpack(decoded_evidence)
 
-    # Fetch policy from Redis
-    try:
-        policy_json, key_id = get_policy_from_redis(redis_client, policy_id)
-    except ValueError as e:
-        logger.error(f"Policy fetching failed for: '{policy_id}': {e}")
-        return False, None, str(e)
     update = (
         policy_json.get("validation_rules", {}).get("tcb", {}).get("update", "standard")
     )
@@ -691,12 +680,11 @@ def tdx_vm_verify(
         verified = policy.validate_quote(quote, tcb_dict, report_data)
         logger.info("Policy validation successful for TDX quote")
         log_function_exit("tdx_vm_verify", "success")
-        return verified, key_id, None
+        return verified, None
     except Exception as e:
         logger.error(f"Policy validation failed for TDX quote: {e}")
         log_function_exit("tdx_vm_verify", "failure")
-        return False, None, "Policy validation failed for TDX quote"
-    return False, None, None
+        return False, "Policy validation failed for TDX quote"
 
 
 def vm_verify(
@@ -759,6 +747,35 @@ def vm_verify(
         logger.error("Decoded TEE evidence is empty")
         return False, None, "Decoded TEE evidence is empty"
 
+    # --- Fetch policy early for components ---
+    try:
+        policy_json, key_id = get_policy_from_redis(redis_client, policy_id)
+    except ValueError as e:
+        logger.error(f"Policy fetching failed for: '{policy_id}': {e}")
+        return False, None, str(e)
+
+    # Extract GPU component policy (if present)
+    gpu_component_policy = None
+    components = policy_json.get("components")
+    if components and isinstance(components, dict):
+        gpu_component_policy = components.get("gpu")
+
+    # Validate: if GPU policy requires GPUs but none were provided
+    if gpu_component_policy and not gpu_list:
+        logger.error("Policy requires GPU attestation but no GPU evidence provided")
+        return (
+            False,
+            None,
+            "Policy requires GPU attestation but no GPU evidence provided",
+        )
+
+    # If GPU evidence provided but no GPU policy, log warning (still verify GPUs)
+    if gpu_list and not gpu_component_policy:
+        logger.warning(
+            "GPU evidence provided but policy has no 'components.gpu' section — "
+            "GPU attestation will proceed without policy validation"
+        )
+
     # --- Compute expected report_data ---
     if report_data_binding and wrapping_key:
         # Recompute the same SHA-512 binding the agent used
@@ -775,11 +792,20 @@ def vm_verify(
             # Verify each GPU and build hash chain in a single pass
             gpu_hashes = []
             for gpu_entry in gpu_list_sorted:
+                # GPU policy is keyed by device type (e.g. "gpu-nvidia")
+                gpu_type = gpu_entry.get("type", "gpu-nvidia")
+                gpu_policy_for_device = (
+                    gpu_component_policy.get(gpu_type)
+                    if isinstance(gpu_component_policy, dict)
+                    else None
+                )
+
                 gpu_ok, _, gpu_err = gpu_vm_verify(
-                    gpu_entry.get("type", "unknown"),
+                    gpu_type,
                     gpu_entry.get("evidence", ""),
                     gpu_entry.get("device-index", -1),
                     expected_nonce=nonce,
+                    gpu_policy=gpu_policy_for_device,
                 )
                 if not gpu_ok:
                     return False, None, gpu_err
@@ -802,24 +828,25 @@ def vm_verify(
     logger.info(f"Verifying evidence for TEE type: {tee_type}")
 
     if tee_type == "amd-sev-snp":
-        result = sev_vm_verify(
+        verified, verify_error = sev_vm_verify(
             redis_client,
             nonce,
             decoded_evidence,
-            policy_id,
+            policy_json,
             expected_report_data=expected_report_data,
         )
     elif tee_type == "intel-tdx":
-        result = tdx_vm_verify(
+        verified, verify_error = tdx_vm_verify(
             redis_client,
             nonce,
             decoded_evidence,
-            policy_id,
+            policy_json,
             expected_report_data=expected_report_data,
         )
     else:
         logger.error(f"Unsupported TEE type: {tee_type}")
         return False, None, "Unsupported TEE type"
 
+    result = (verified, key_id if verified else None, verify_error)
     log_function_exit("vm_verify", result)
     return result

--- a/tas/tas_vm.py
+++ b/tas/tas_vm.py
@@ -10,6 +10,7 @@
 #
 
 import base64
+import datetime
 import hashlib
 import json
 import os
@@ -19,8 +20,30 @@ import redis
 import sev_pytools as sev
 import tdx_pytools as tdx
 from cryptography import x509
-from cryptography.hazmat.primitives import serialization
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, padding, utils
 from flask import current_app
+
+try:
+    from tas.components.gpu_nvidia import gpu_vm_verify
+
+    GPU_ATTESTATION_AVAILABLE = True
+except ImportError:
+    GPU_ATTESTATION_AVAILABLE = False
+
+    def gpu_vm_verify(
+        gpu_tee_type, gpu_evidence_b64, device_index, expected_nonce=None
+    ):
+        return (
+            False,
+            None,
+            (
+                f"GPU {device_index}: GPU attestation not available "
+                "(nvidia_pytools not installed)"
+            ),
+        )
+
 
 from tas.policy_helper import is_policy_signed, verify_policy_signature
 from tas.tas_logging import get_logger, log_function_entry, log_function_exit
@@ -676,42 +699,6 @@ def tdx_vm_verify(
     return False, None, None
 
 
-def gpu_vm_verify(gpu_tee_type, gpu_evidence_b64, device_index):
-    """
-    Verify a single GPU's attestation evidence (stub).
-
-    Parameters:
-        gpu_tee_type (str): The type of GPU TEE (e.g., "nvidia-hopper").
-        gpu_evidence_b64 (str): Base64-encoded GPU attestation evidence.
-        device_index (int): The index of the GPU device being verified.
-
-    Returns:
-        is_verified (bool): True if verification is successful, False otherwise.
-        key_id (str or None): The key ID to fetch if the policy used for verification is successful, None otherwise.
-        verify_error (str or None): An error message if verification fails, None otherwise.
-    """
-    log_function_entry("gpu_vm_verify")
-    try:
-        gpu_raw = base64.b64decode(gpu_evidence_b64)
-        if len(gpu_raw) == 0:
-            return False, None, f"GPU {device_index}: empty evidence"
-
-        # TODO: dispatch to GPU-specific verification based on gpu_tee_type
-        logger.warning(
-            f"GPU {device_index} ({gpu_tee_type}): "
-            "verification not yet implemented, accepting on structure only"
-        )
-        log_function_exit("gpu_vm_verify", "stub-accepted")
-        return (
-            False,
-            None,
-            f"GPU {device_index} ({gpu_tee_type}): verification not yet implemented",
-        )
-    except Exception as e:
-        log_function_exit("gpu_vm_verify", "error")
-        return False, None, f"GPU {device_index} verification error: {e}"
-
-
 def vm_verify(
     redis_client,
     nonce,
@@ -720,7 +707,7 @@ def vm_verify(
     policy_id,
     wrapping_key=None,
     report_data_binding=False,
-    gpu_evidence=None,
+    gpu_list=None,
 ):
     """
     Verifies the provided nonce, TEE type, and TEE evidence, with optional
@@ -738,10 +725,10 @@ def vm_verify(
             [|| SHA-512(gpu0_evidence) || SHA-512(gpu1_evidence) || ...])
             instead of using the raw nonce. Must be provided
             in the request; cannot be None.
-        gpu_evidence (list, optional): List of per-GPU attestation evidence dicts,
+        gpu_list (list, optional): List of per-GPU attestation evidence dicts,
             each containing:
-                - "tee-type"      (str): GPU TEE type (e.g., "nvidia-hopper").
-                - "tee-evidence"  (str): Base64-encoded GPU attestation evidence.
+                - "type"      (str): GPU TEE type (e.g., "gpu-nvidia").
+                - "evidence"  (str): Base64-encoded GPU attestation evidence.
                 - "device-index"  (int): GPU device index (used for ordering).
             When present and report_data_binding is True, each GPU is verified
             independently via gpu_vm_verify and its SHA-512 evidence hash is
@@ -777,27 +764,32 @@ def vm_verify(
         # Recompute the same SHA-512 binding the agent used
         hash_input = nonce.encode("utf-8") + wrapping_key
 
-        # Phase 2: include per-GPU evidence hashes
-        if gpu_evidence:
-            if len(gpu_evidence) > 16:
-                logger.error(f"Too many GPU evidence entries: {len(gpu_evidence)}")
+        # Include per-GPU evidence hashes
+        if gpu_list:
+            if len(gpu_list) > 16:
+                logger.error(f"Too many GPU evidence entries: {len(gpu_list)}")
                 return False, None, "Too many GPU evidence entries (max 16)"
 
-            gpu_evidence_sorted = sorted(gpu_evidence, key=lambda e: e["device-index"])
+            gpu_list_sorted = sorted(gpu_list, key=lambda e: e["device-index"])
 
             # Verify each GPU and build hash chain in a single pass
             gpu_hashes = []
-            for gpu_entry in gpu_evidence_sorted:
+            for gpu_entry in gpu_list_sorted:
                 gpu_ok, _, gpu_err = gpu_vm_verify(
-                    gpu_entry.get("tee-type", "unknown"),
-                    gpu_entry.get("tee-evidence", ""),
+                    gpu_entry.get("type", "unknown"),
+                    gpu_entry.get("evidence", ""),
                     gpu_entry.get("device-index", -1),
+                    expected_nonce=nonce,
                 )
                 if not gpu_ok:
                     return False, None, gpu_err
 
-                gpu_raw = base64.b64decode(gpu_entry["tee-evidence"])
-                gpu_hashes.append(hashlib.sha512(gpu_raw).digest())
+                # Hash the inner raw evidence (the binary GPU attestation report).
+                # Decode outer base64 → JSON envelope → decode inner "evidence" → raw bytes.
+                gpu_envelope_raw = base64.b64decode(gpu_entry["evidence"])
+                gpu_envelope = json.loads(gpu_envelope_raw)
+                inner_evidence_raw = base64.b64decode(gpu_envelope["evidence"])
+                gpu_hashes.append(hashlib.sha512(inner_evidence_raw).digest())
 
             # Append SHA-512 hashes: SHA512(gpu0_raw) || SHA512(gpu1_raw) || ...
             for h in gpu_hashes:

--- a/tests/test_tas_vm.py
+++ b/tests/test_tas_vm.py
@@ -14,6 +14,9 @@ from unittest.mock import MagicMock, patch
 
 from tas.tas_vm import gpu_vm_verify, vm_verify
 
+# A minimal valid policy JSON for mocking get_policy_from_redis
+_MOCK_POLICY = {"metadata": {"key_id": "test-key"}, "validation_rules": {}}
+
 # ── gpu_vm_verify tests ─────────────────────────────────────────────
 
 
@@ -51,6 +54,7 @@ class TestGpuVmVerify:
             gpu_evidence_b64=self.EVIDENCE_B64,
             device_index=0,
             expected_nonce=None,
+            policy=None,
         )
 
     @patch("tas.components.gpu_nvidia.nvidia_pytools")
@@ -83,6 +87,7 @@ class TestGpuVmVerify:
             gpu_evidence_b64=self.EVIDENCE_B64,
             device_index=2,
             expected_nonce="abc123",
+            policy=None,
         )
 
     def test_fallback_stub_when_import_fails(self):
@@ -140,6 +145,10 @@ class TestVmVerifyInputValidation:
 # ── vm_verify report_data_binding tests ─────────────────────────────
 
 
+@patch(
+    "tas.tas_vm.get_policy_from_redis",
+    return_value=(_MOCK_POLICY, "test-key"),
+)
 class TestVmVerifyReportDataBinding:
     """Tests for the report_data_binding computation in vm_verify."""
 
@@ -149,9 +158,9 @@ class TestVmVerifyReportDataBinding:
     KEY_ID = "test-key"
 
     @patch("tas.tas_vm.sev_vm_verify")
-    def test_binding_computes_sha512(self, mock_sev):
+    def test_binding_computes_sha512(self, mock_sev, _mock_policy):
         """With report_data_binding=True, expected_report_data should be SHA-512."""
-        mock_sev.return_value = (True, "test-key", None)
+        mock_sev.return_value = (True, None)
 
         vm_verify(
             MagicMock(),
@@ -170,9 +179,9 @@ class TestVmVerifyReportDataBinding:
         assert call_kwargs.kwargs["expected_report_data"] == expected
 
     @patch("tas.tas_vm.sev_vm_verify")
-    def test_no_binding_uses_nonce(self, mock_sev):
+    def test_no_binding_uses_nonce(self, mock_sev, _mock_policy):
         """Without binding, expected_report_data should be the raw nonce bytes."""
-        mock_sev.return_value = (True, "test-key", None)
+        mock_sev.return_value = (True, None)
 
         vm_verify(
             MagicMock(),
@@ -186,9 +195,9 @@ class TestVmVerifyReportDataBinding:
         assert call_kwargs.kwargs["expected_report_data"] == self.NONCE.encode("utf-8")
 
     @patch("tas.tas_vm.sev_vm_verify")
-    def test_binding_false_uses_nonce(self, mock_sev):
+    def test_binding_false_uses_nonce(self, mock_sev, _mock_policy):
         """report_data_binding=False should use the raw nonce even with wrapping_key."""
-        mock_sev.return_value = (True, "test-key", None)
+        mock_sev.return_value = (True, None)
 
         vm_verify(
             MagicMock(),
@@ -204,9 +213,9 @@ class TestVmVerifyReportDataBinding:
         assert call_kwargs.kwargs["expected_report_data"] == self.NONCE.encode("utf-8")
 
     @patch("tas.tas_vm.sev_vm_verify")
-    def test_binding_true_no_wrapping_key_uses_nonce(self, mock_sev):
+    def test_binding_true_no_wrapping_key_uses_nonce(self, mock_sev, _mock_policy):
         """report_data_binding=True without wrapping_key should fall back to nonce."""
-        mock_sev.return_value = (True, "test-key", None)
+        mock_sev.return_value = (True, None)
 
         vm_verify(
             MagicMock(),
@@ -222,9 +231,9 @@ class TestVmVerifyReportDataBinding:
         assert call_kwargs.kwargs["expected_report_data"] == self.NONCE.encode("utf-8")
 
     @patch("tas.tas_vm.tdx_vm_verify")
-    def test_binding_dispatches_to_tdx(self, mock_tdx):
+    def test_binding_dispatches_to_tdx(self, mock_tdx, _mock_policy):
         """Binding should work for intel-tdx as well."""
-        mock_tdx.return_value = (True, "test-key", None)
+        mock_tdx.return_value = (True, None)
 
         vm_verify(
             MagicMock(),
@@ -246,6 +255,10 @@ class TestVmVerifyReportDataBinding:
 # ── vm_verify return value propagation tests ────────────────────────
 
 
+@patch(
+    "tas.tas_vm.get_policy_from_redis",
+    return_value=(_MOCK_POLICY, "prop-key"),
+)
 class TestVmVerifyReturnPropagation:
     """Tests that vm_verify correctly returns the result from TEE verifiers."""
 
@@ -254,9 +267,9 @@ class TestVmVerifyReturnPropagation:
     KEY_ID = "prop-key"
 
     @patch("tas.tas_vm.sev_vm_verify")
-    def test_sev_success_propagated(self, mock_sev):
+    def test_sev_success_propagated(self, mock_sev, _mock_policy):
         """vm_verify should return (True, key_id, None) when sev_vm_verify succeeds."""
-        mock_sev.return_value = (True, "prop-key", None)
+        mock_sev.return_value = (True, None)
         ok, key_id, err = vm_verify(
             MagicMock(), self.NONCE, "amd-sev-snp", self.TEE_EVIDENCE_B64, self.KEY_ID
         )
@@ -265,9 +278,9 @@ class TestVmVerifyReturnPropagation:
         assert err is None
 
     @patch("tas.tas_vm.sev_vm_verify")
-    def test_sev_failure_propagated(self, mock_sev):
+    def test_sev_failure_propagated(self, mock_sev, _mock_policy):
         """vm_verify should return (False, None, error) when sev_vm_verify fails."""
-        mock_sev.return_value = (False, None, "SEV verification failed")
+        mock_sev.return_value = (False, "SEV verification failed")
         ok, key_id, err = vm_verify(
             MagicMock(), self.NONCE, "amd-sev-snp", self.TEE_EVIDENCE_B64, self.KEY_ID
         )
@@ -276,9 +289,9 @@ class TestVmVerifyReturnPropagation:
         assert err == "SEV verification failed"
 
     @patch("tas.tas_vm.tdx_vm_verify")
-    def test_tdx_success_propagated(self, mock_tdx):
+    def test_tdx_success_propagated(self, mock_tdx, _mock_policy):
         """vm_verify should return (True, key_id, None) when tdx_vm_verify succeeds."""
-        mock_tdx.return_value = (True, "prop-key", None)
+        mock_tdx.return_value = (True, None)
         ok, key_id, err = vm_verify(
             MagicMock(), self.NONCE, "intel-tdx", self.TEE_EVIDENCE_B64, self.KEY_ID
         )
@@ -287,9 +300,9 @@ class TestVmVerifyReturnPropagation:
         assert err is None
 
     @patch("tas.tas_vm.tdx_vm_verify")
-    def test_tdx_failure_propagated(self, mock_tdx):
+    def test_tdx_failure_propagated(self, mock_tdx, _mock_policy):
         """vm_verify should return (False, None, error) when tdx_vm_verify fails."""
-        mock_tdx.return_value = (False, None, "TDX verification failed")
+        mock_tdx.return_value = (False, "TDX verification failed")
         ok, key_id, err = vm_verify(
             MagicMock(), self.NONCE, "intel-tdx", self.TEE_EVIDENCE_B64, self.KEY_ID
         )
@@ -301,6 +314,10 @@ class TestVmVerifyReturnPropagation:
 # ── vm_verify GPU evidence tests ────────────────────────────────────
 
 
+@patch(
+    "tas.tas_vm.get_policy_from_redis",
+    return_value=(_MOCK_POLICY, "gpu-key"),
+)
 class TestVmVerifyGpuEvidence:
     """Tests for GPU evidence handling in vm_verify."""
 
@@ -321,7 +338,7 @@ class TestVmVerifyGpuEvidence:
     def GPU_EVIDENCE_B64(self):
         return self._make_envelope(self.GPU_EVIDENCE_RAW)
 
-    def test_gpu_evidence_too_many_rejected(self):
+    def test_gpu_evidence_too_many_rejected(self, _mock_policy):
         """More than 16 GPU entries should be rejected."""
         gpu_evidence = [
             {
@@ -344,7 +361,7 @@ class TestVmVerifyGpuEvidence:
         assert ok is False
         assert "max 16" in err
 
-    def test_gpu_evidence_exactly_16_passes_cap(self):
+    def test_gpu_evidence_exactly_16_passes_cap(self, _mock_policy):
         """Exactly 16 GPU entries should not be rejected by the cap."""
         gpu_evidence = [
             {
@@ -368,7 +385,7 @@ class TestVmVerifyGpuEvidence:
         # Error should be from gpu_vm_verify stub, not the cap
         assert "max 16" not in err
 
-    def test_gpu_failure_stops_verification(self):
+    def test_gpu_failure_stops_verification(self, _mock_policy):
         """If a GPU fails verification, vm_verify should return its error."""
         gpu_evidence = [
             {
@@ -392,9 +409,9 @@ class TestVmVerifyGpuEvidence:
 
     @patch("tas.tas_vm.gpu_vm_verify", return_value=(True, None, None))
     @patch("tas.tas_vm.sev_vm_verify")
-    def test_gpu_hashes_included_in_binding(self, mock_sev, mock_gpu):
+    def test_gpu_hashes_included_in_binding(self, mock_sev, mock_gpu, _mock_policy):
         """GPU evidence SHA-512 hashes should be included in the binding."""
-        mock_sev.return_value = (True, "test-key", None)
+        mock_sev.return_value = (True, None)
 
         gpu0_raw = b"\xaa\xbb"
         gpu1_raw = b"\xcc\xdd"
@@ -433,9 +450,11 @@ class TestVmVerifyGpuEvidence:
 
     @patch("tas.tas_vm.gpu_vm_verify", return_value=(True, None, None))
     @patch("tas.tas_vm.sev_vm_verify")
-    def test_gpu_evidence_sorted_by_device_index(self, mock_sev, mock_gpu):
+    def test_gpu_evidence_sorted_by_device_index(
+        self, mock_sev, mock_gpu, _mock_policy
+    ):
         """GPU evidence should be sorted by device-index for deterministic hashing."""
-        mock_sev.return_value = (True, "test-key", None)
+        mock_sev.return_value = (True, None)
 
         gpu_entries = [
             {
@@ -471,7 +490,7 @@ class TestVmVerifyGpuEvidence:
         device_indices = [c.args[2] for c in calls]
         assert device_indices == [0, 1, 2]
 
-    def test_gpu_evidence_without_binding_ignored(self):
+    def test_gpu_evidence_without_binding_ignored(self, _mock_policy):
         """GPU evidence without report_data_binding should not trigger GPU verify."""
         gpu_evidence = [
             {
@@ -484,7 +503,7 @@ class TestVmVerifyGpuEvidence:
             patch("tas.tas_vm.sev_vm_verify") as mock_sev,
             patch("tas.tas_vm.gpu_vm_verify") as mock_gpu,
         ):
-            mock_sev.return_value = (True, "test-key", None)
+            mock_sev.return_value = (True, None)
 
             vm_verify(
                 MagicMock(),
@@ -501,9 +520,11 @@ class TestVmVerifyGpuEvidence:
 
     @patch("tas.tas_vm.gpu_vm_verify", return_value=(True, None, None))
     @patch("tas.tas_vm.sev_vm_verify")
-    def test_binding_without_gpu_evidence_no_gpu_verify(self, mock_sev, mock_gpu):
+    def test_binding_without_gpu_evidence_no_gpu_verify(
+        self, mock_sev, mock_gpu, _mock_policy
+    ):
         """Binding without gpu_evidence should not call gpu_vm_verify."""
-        mock_sev.return_value = (True, "test-key", None)
+        mock_sev.return_value = (True, None)
 
         vm_verify(
             MagicMock(),
@@ -527,7 +548,9 @@ class TestVmVerifyGpuEvidence:
 
     @patch("tas.tas_vm.gpu_vm_verify")
     @patch("tas.tas_vm.sev_vm_verify")
-    def test_second_gpu_failure_after_first_passes(self, mock_sev, mock_gpu):
+    def test_second_gpu_failure_after_first_passes(
+        self, mock_sev, mock_gpu, _mock_policy
+    ):
         """If the second GPU fails, its error should be returned."""
         mock_gpu.side_effect = [
             (True, None, None),  # GPU 0 passes
@@ -560,3 +583,242 @@ class TestVmVerifyGpuEvidence:
 
         assert ok is False
         assert "GPU 1" in err
+
+
+# ── vm_verify GPU policy tests ──────────────────────────────────────
+
+# Example NVIDIA GPU policy (as stored in components.gpu.nvidia)
+_NVIDIA_GPU_POLICY = {
+    "version": "4.0",
+    "authorization-rules": {
+        "type": "JWT",
+        "overall-claims": {
+            "x-nvidia-overall-att-result": True,
+        },
+        "detached-claims": {
+            "measres": "success",
+            "dbgstat": "disabled",
+        },
+    },
+}
+
+# A policy with the components.gpu section keyed by device type
+_POLICY_WITH_GPU = {
+    "metadata": {"key_id": "gpu-test-key"},
+    "validation_rules": {},
+    "components": {
+        "gpu": {
+            "gpu-nvidia": _NVIDIA_GPU_POLICY,
+        }
+    },
+}
+
+# A policy without any components section
+_POLICY_NO_COMPONENTS = {
+    "metadata": {"key_id": "no-gpu-key"},
+    "validation_rules": {},
+}
+
+
+class TestVmVerifyGpuPolicy:
+    """Tests for GPU component policy extraction and application in vm_verify."""
+
+    NONCE = "gpu-policy-nonce"
+    TEE_EVIDENCE_B64 = base64.b64encode(b"\xca\xfe").decode()
+    WRAPPING_KEY = b"\x22" * 16
+    KEY_ID = "gpu-policy-key"
+
+    @staticmethod
+    def _make_envelope(raw_bytes):
+        inner_b64 = base64.b64encode(raw_bytes).decode()
+        envelope = json.dumps({"evidence": inner_b64})
+        return base64.b64encode(envelope.encode()).decode()
+
+    @patch(
+        "tas.tas_vm.get_policy_from_redis",
+        return_value=(_POLICY_WITH_GPU, "gpu-test-key"),
+    )
+    def test_gpu_required_by_policy_but_no_evidence_fails(self, _mock_policy):
+        """If policy has components.gpu but no GPU evidence provided, fail."""
+        ok, _, err = vm_verify(
+            MagicMock(),
+            self.NONCE,
+            "amd-sev-snp",
+            self.TEE_EVIDENCE_B64,
+            self.KEY_ID,
+            wrapping_key=self.WRAPPING_KEY,
+            report_data_binding=True,
+            gpu_list=None,
+        )
+        assert ok is False
+        assert "requires GPU attestation" in err
+
+    @patch(
+        "tas.tas_vm.get_policy_from_redis",
+        return_value=(_POLICY_NO_COMPONENTS, "no-gpu-key"),
+    )
+    @patch("tas.tas_vm.sev_vm_verify")
+    def test_gpu_evidence_without_policy_warns_but_passes(self, mock_sev, _mock_policy):
+        """GPU evidence without components.gpu in policy logs warning, still verifies."""
+        mock_sev.return_value = (True, None)
+        gpu_evidence = [
+            {
+                "type": "nvidia-hopper",
+                "evidence": self._make_envelope(b"\xaa"),
+                "device-index": 0,
+            },
+        ]
+
+        # GPU verify will be called without policy (None), should still work
+        with patch("tas.tas_vm.gpu_vm_verify", return_value=(True, None, None)):
+            ok, key_id, err = vm_verify(
+                MagicMock(),
+                self.NONCE,
+                "amd-sev-snp",
+                self.TEE_EVIDENCE_B64,
+                self.KEY_ID,
+                wrapping_key=self.WRAPPING_KEY,
+                report_data_binding=True,
+                gpu_list=gpu_evidence,
+            )
+        assert ok is True
+        assert err is None
+
+    @patch(
+        "tas.tas_vm.get_policy_from_redis",
+        return_value=(_POLICY_WITH_GPU, "gpu-test-key"),
+    )
+    @patch("tas.tas_vm.gpu_vm_verify")
+    @patch("tas.tas_vm.sev_vm_verify")
+    def test_nvidia_policy_passed_to_gpu_vm_verify(
+        self, mock_sev, mock_gpu, _mock_policy
+    ):
+        """The NVIDIA policy should be passed to gpu_vm_verify for gpu-nvidia GPUs."""
+        mock_sev.return_value = (True, None)
+        mock_gpu.return_value = (True, None, None)
+
+        gpu_evidence = [
+            {
+                "type": "gpu-nvidia",
+                "evidence": self._make_envelope(b"\xbb"),
+                "device-index": 0,
+            },
+        ]
+
+        vm_verify(
+            MagicMock(),
+            self.NONCE,
+            "amd-sev-snp",
+            self.TEE_EVIDENCE_B64,
+            self.KEY_ID,
+            wrapping_key=self.WRAPPING_KEY,
+            report_data_binding=True,
+            gpu_list=gpu_evidence,
+        )
+
+        # gpu_vm_verify should be called with the nvidia policy
+        call_kwargs = mock_gpu.call_args
+        assert call_kwargs.kwargs["gpu_policy"] == _NVIDIA_GPU_POLICY
+
+    @patch(
+        "tas.tas_vm.get_policy_from_redis",
+        return_value=(_POLICY_WITH_GPU, "gpu-test-key"),
+    )
+    @patch("tas.tas_vm.gpu_vm_verify")
+    @patch("tas.tas_vm.sev_vm_verify")
+    def test_non_matching_device_type_gets_no_policy(
+        self, mock_sev, mock_gpu, _mock_policy
+    ):
+        """GPUs whose device type has no matching policy key get gpu_policy=None."""
+        mock_sev.return_value = (True, None)
+        mock_gpu.return_value = (True, None, None)
+
+        gpu_evidence = [
+            {
+                "type": "amd-gpu",
+                "evidence": self._make_envelope(b"\xcc"),
+                "device-index": 0,
+            },
+        ]
+
+        vm_verify(
+            MagicMock(),
+            self.NONCE,
+            "amd-sev-snp",
+            self.TEE_EVIDENCE_B64,
+            self.KEY_ID,
+            wrapping_key=self.WRAPPING_KEY,
+            report_data_binding=True,
+            gpu_list=gpu_evidence,
+        )
+
+        call_kwargs = mock_gpu.call_args
+        assert call_kwargs.kwargs["gpu_policy"] is None
+
+
+# ── gpu_vm_verify with policy tests ────────────────────────────────
+
+
+class TestGpuVmVerifyWithPolicy:
+    """Tests for gpu_vm_verify when a policy is provided."""
+
+    EVIDENCE_B64 = base64.b64encode(b"\x01\x02\x03").decode()
+
+    @patch("tas.components.gpu_nvidia.nvidia_pytools")
+    @patch("tas.components.gpu_nvidia.GPU_PYTOOLS_AVAILABLE", True)
+    def test_policy_passed_constructs_attestation_policy(self, mock_nvidia):
+        """When gpu_policy is provided, an AttestationPolicy should be created."""
+        from tas.components.gpu_nvidia import gpu_vm_verify as direct_verify
+
+        mock_claims = MagicMock()
+        mock_claims.hwmodel = "H100"
+        mock_nvidia.verify_gpu_evidence.return_value = (True, mock_claims, None)
+        mock_nvidia.AttestationPolicy.return_value = MagicMock()
+
+        direct_verify(
+            "gpu-nvidia",
+            self.EVIDENCE_B64,
+            0,
+            gpu_policy=_NVIDIA_GPU_POLICY,
+        )
+
+        mock_nvidia.AttestationPolicy.assert_called_once_with(
+            policy_data=_NVIDIA_GPU_POLICY
+        )
+        # The constructed policy should be passed to verify_gpu_evidence
+        call_kwargs = mock_nvidia.verify_gpu_evidence.call_args
+        assert call_kwargs.kwargs["policy"] is not None
+
+    @patch("tas.components.gpu_nvidia.nvidia_pytools")
+    @patch("tas.components.gpu_nvidia.GPU_PYTOOLS_AVAILABLE", True)
+    def test_no_policy_passes_none(self, mock_nvidia):
+        """When gpu_policy is None, policy=None should be passed to verify."""
+        from tas.components.gpu_nvidia import gpu_vm_verify as direct_verify
+
+        mock_nvidia.verify_gpu_evidence.return_value = (True, MagicMock(), None)
+
+        direct_verify("gpu-nvidia", self.EVIDENCE_B64, 0, gpu_policy=None)
+
+        call_kwargs = mock_nvidia.verify_gpu_evidence.call_args
+        assert call_kwargs.kwargs["policy"] is None
+
+    @patch("tas.components.gpu_nvidia.nvidia_pytools")
+    @patch("tas.components.gpu_nvidia.GPU_PYTOOLS_AVAILABLE", True)
+    def test_invalid_policy_returns_error(self, mock_nvidia):
+        """If the policy is malformed, return an error without calling verify."""
+        from tas.components.gpu_nvidia import gpu_vm_verify as direct_verify
+
+        mock_nvidia.AttestationPolicy.side_effect = ValueError(
+            "Policy missing required section: authorization-rules"
+        )
+
+        ok, key_id, err = direct_verify(
+            "gpu-nvidia",
+            self.EVIDENCE_B64,
+            0,
+            gpu_policy={"bad": "policy"},
+        )
+
+        assert ok is False
+        assert "invalid GPU policy" in err
+        mock_nvidia.verify_gpu_evidence.assert_not_called()

--- a/tests/test_tas_vm.py
+++ b/tests/test_tas_vm.py
@@ -9,6 +9,7 @@
 
 import base64
 import hashlib
+import json
 from unittest.mock import MagicMock, patch
 
 from tas.tas_vm import gpu_vm_verify, vm_verify
@@ -17,41 +18,82 @@ from tas.tas_vm import gpu_vm_verify, vm_verify
 
 
 class TestGpuVmVerify:
-    """Tests for the gpu_vm_verify stub function."""
+    """Tests for the gpu_vm_verify function (nvidia_pytools integration)."""
 
-    def test_empty_evidence_returns_error(self):
-        """Empty base64 payload should be rejected."""
-        empty_b64 = base64.b64encode(b"").decode()
-        ok, _, err = gpu_vm_verify("nvidia-hopper", empty_b64, 0)
-        assert ok is False
-        assert "empty evidence" in err
+    EVIDENCE_B64 = base64.b64encode(b"\x01\x02\x03").decode()
 
-    def test_valid_evidence_returns_not_implemented(self):
-        """Non-empty evidence should return a 'not implemented' error (stub)."""
-        evidence_b64 = base64.b64encode(b"\x01\x02\x03").decode()
-        ok, _, err = gpu_vm_verify("nvidia-hopper", evidence_b64, 0)
-        assert ok is False
-        assert "not yet implemented" in err
+    @patch("tas.components.gpu_nvidia.GPU_PYTOOLS_AVAILABLE", False)
+    def test_unavailable_returns_install_message(self):
+        """When nvidia_pytools is not installed, return an actionable error."""
+        from tas.components.gpu_nvidia import gpu_vm_verify as direct_verify
 
-    def test_invalid_base64_returns_error(self):
-        """Invalid base64 should be caught and return an error."""
-        ok, _, err = gpu_vm_verify("nvidia-hopper", "!!!not-base64!!!", 0)
+        ok, key_id, err = direct_verify("gpu-nvidia", self.EVIDENCE_B64, 0)
         assert ok is False
-        assert "verification error" in err
+        assert key_id is None
+        assert "not installed" in err
+        assert "0" in err
 
-    def test_device_index_in_error_message(self):
-        """Device index should appear in the error message."""
-        evidence_b64 = base64.b64encode(b"\xaa").decode()
-        ok, _, err = gpu_vm_verify("nvidia-hopper", evidence_b64, 42)
-        assert ok is False
-        assert "42" in err
+    @patch("tas.components.gpu_nvidia.nvidia_pytools")
+    @patch("tas.components.gpu_nvidia.GPU_PYTOOLS_AVAILABLE", True)
+    def test_successful_verification(self, mock_nvidia):
+        """Successful nvidia_pytools verification returns (True, None, None)."""
+        from tas.components.gpu_nvidia import gpu_vm_verify as direct_verify
 
-    def test_tee_type_in_error_message(self):
-        """GPU TEE type should appear in the error message."""
-        evidence_b64 = base64.b64encode(b"\xaa").decode()
-        ok, _, err = gpu_vm_verify("nvidia-hopper", evidence_b64, 0)
+        mock_claims = MagicMock()
+        mock_claims.hwmodel = "H100"
+        mock_nvidia.verify_gpu_evidence.return_value = (True, mock_claims, None)
+
+        ok, key_id, err = direct_verify("gpu-nvidia", self.EVIDENCE_B64, 0)
+        assert ok is True
+        assert key_id is None
+        assert err is None
+        mock_nvidia.verify_gpu_evidence.assert_called_once_with(
+            gpu_evidence_b64=self.EVIDENCE_B64,
+            device_index=0,
+            expected_nonce=None,
+        )
+
+    @patch("tas.components.gpu_nvidia.nvidia_pytools")
+    @patch("tas.components.gpu_nvidia.GPU_PYTOOLS_AVAILABLE", True)
+    def test_failed_verification_propagates_error(self, mock_nvidia):
+        """Failed nvidia_pytools verification propagates the error string."""
+        from tas.components.gpu_nvidia import gpu_vm_verify as direct_verify
+
+        mock_nvidia.verify_gpu_evidence.return_value = (
+            False,
+            None,
+            "GPU 0: token signature invalid",
+        )
+
+        ok, key_id, err = direct_verify("gpu-nvidia", self.EVIDENCE_B64, 0)
         assert ok is False
-        assert "nvidia-hopper" in err
+        assert key_id is None
+        assert "token signature invalid" in err
+
+    @patch("tas.components.gpu_nvidia.nvidia_pytools")
+    @patch("tas.components.gpu_nvidia.GPU_PYTOOLS_AVAILABLE", True)
+    def test_nonce_passed_to_nvidia_pytools(self, mock_nvidia):
+        """expected_nonce should be forwarded to nvidia_pytools."""
+        from tas.components.gpu_nvidia import gpu_vm_verify as direct_verify
+
+        mock_nvidia.verify_gpu_evidence.return_value = (True, MagicMock(), None)
+
+        direct_verify("gpu-nvidia", self.EVIDENCE_B64, 2, expected_nonce="abc123")
+        mock_nvidia.verify_gpu_evidence.assert_called_once_with(
+            gpu_evidence_b64=self.EVIDENCE_B64,
+            device_index=2,
+            expected_nonce="abc123",
+        )
+
+    def test_fallback_stub_when_import_fails(self):
+        """The fallback stub in tas_vm should mention nvidia_pytools not installed."""
+        # gpu_vm_verify imported at module level falls back if import fails;
+        # test the actual imported function (may be real or stub depending on env)
+        ok, key_id, err = gpu_vm_verify("gpu-nvidia", self.EVIDENCE_B64, 3)
+        # Either it works (nvidia_pytools installed) or returns a clear error
+        assert isinstance(ok, bool)
+        if not ok:
+            assert "3" in err or "GPU" in err
 
 
 # ── vm_verify input validation tests ────────────────────────────────
@@ -267,14 +309,24 @@ class TestVmVerifyGpuEvidence:
     WRAPPING_KEY = b"\x11" * 16
     KEY_ID = "gpu-key"
     GPU_EVIDENCE_RAW = b"\xaa\xbb\xcc"
-    GPU_EVIDENCE_B64 = base64.b64encode(GPU_EVIDENCE_RAW).decode()
+
+    @staticmethod
+    def _make_envelope(raw_bytes):
+        """Build a GPU evidence envelope: base64(json({"evidence": base64(raw)}))."""
+        inner_b64 = base64.b64encode(raw_bytes).decode()
+        envelope = json.dumps({"evidence": inner_b64})
+        return base64.b64encode(envelope.encode()).decode()
+
+    @property
+    def GPU_EVIDENCE_B64(self):
+        return self._make_envelope(self.GPU_EVIDENCE_RAW)
 
     def test_gpu_evidence_too_many_rejected(self):
         """More than 16 GPU entries should be rejected."""
         gpu_evidence = [
             {
-                "tee-type": "nvidia-hopper",
-                "tee-evidence": self.GPU_EVIDENCE_B64,
+                "type": "nvidia-hopper",
+                "evidence": self.GPU_EVIDENCE_B64,
                 "device-index": i,
             }
             for i in range(17)
@@ -287,7 +339,7 @@ class TestVmVerifyGpuEvidence:
             self.KEY_ID,
             wrapping_key=self.WRAPPING_KEY,
             report_data_binding=True,
-            gpu_evidence=gpu_evidence,
+            gpu_list=gpu_evidence,
         )
         assert ok is False
         assert "max 16" in err
@@ -296,8 +348,8 @@ class TestVmVerifyGpuEvidence:
         """Exactly 16 GPU entries should not be rejected by the cap."""
         gpu_evidence = [
             {
-                "tee-type": "nvidia-hopper",
-                "tee-evidence": self.GPU_EVIDENCE_B64,
+                "type": "nvidia-hopper",
+                "evidence": self.GPU_EVIDENCE_B64,
                 "device-index": i,
             }
             for i in range(16)
@@ -310,7 +362,7 @@ class TestVmVerifyGpuEvidence:
             self.KEY_ID,
             wrapping_key=self.WRAPPING_KEY,
             report_data_binding=True,
-            gpu_evidence=gpu_evidence,
+            gpu_list=gpu_evidence,
         )
         assert ok is False
         # Error should be from gpu_vm_verify stub, not the cap
@@ -320,8 +372,8 @@ class TestVmVerifyGpuEvidence:
         """If a GPU fails verification, vm_verify should return its error."""
         gpu_evidence = [
             {
-                "tee-type": "nvidia-hopper",
-                "tee-evidence": self.GPU_EVIDENCE_B64,
+                "type": "nvidia-hopper",
+                "evidence": self.GPU_EVIDENCE_B64,
                 "device-index": 0,
             },
         ]
@@ -333,10 +385,10 @@ class TestVmVerifyGpuEvidence:
             self.KEY_ID,
             wrapping_key=self.WRAPPING_KEY,
             report_data_binding=True,
-            gpu_evidence=gpu_evidence,
+            gpu_list=gpu_evidence,
         )
         assert ok is False
-        assert "not yet implemented" in err
+        assert err is not None and "GPU" in err
 
     @patch("tas.tas_vm.gpu_vm_verify", return_value=(True, None, None))
     @patch("tas.tas_vm.sev_vm_verify")
@@ -348,13 +400,13 @@ class TestVmVerifyGpuEvidence:
         gpu1_raw = b"\xcc\xdd"
         gpu_evidence = [
             {
-                "tee-type": "nvidia-hopper",
-                "tee-evidence": base64.b64encode(gpu1_raw).decode(),
+                "type": "nvidia-hopper",
+                "evidence": self._make_envelope(gpu1_raw),
                 "device-index": 1,
             },
             {
-                "tee-type": "nvidia-hopper",
-                "tee-evidence": base64.b64encode(gpu0_raw).decode(),
+                "type": "nvidia-hopper",
+                "evidence": self._make_envelope(gpu0_raw),
                 "device-index": 0,
             },
         ]
@@ -367,7 +419,7 @@ class TestVmVerifyGpuEvidence:
             self.KEY_ID,
             wrapping_key=self.WRAPPING_KEY,
             report_data_binding=True,
-            gpu_evidence=gpu_evidence,
+            gpu_list=gpu_evidence,
         )
 
         # Build expected hash: sorted by device-index (0 first, then 1)
@@ -387,18 +439,18 @@ class TestVmVerifyGpuEvidence:
 
         gpu_entries = [
             {
-                "tee-type": "t",
-                "tee-evidence": base64.b64encode(b"gpu2").decode(),
+                "type": "t",
+                "evidence": self._make_envelope(b"gpu2"),
                 "device-index": 2,
             },
             {
-                "tee-type": "t",
-                "tee-evidence": base64.b64encode(b"gpu0").decode(),
+                "type": "t",
+                "evidence": self._make_envelope(b"gpu0"),
                 "device-index": 0,
             },
             {
-                "tee-type": "t",
-                "tee-evidence": base64.b64encode(b"gpu1").decode(),
+                "type": "t",
+                "evidence": self._make_envelope(b"gpu1"),
                 "device-index": 1,
             },
         ]
@@ -411,7 +463,7 @@ class TestVmVerifyGpuEvidence:
             self.KEY_ID,
             wrapping_key=self.WRAPPING_KEY,
             report_data_binding=True,
-            gpu_evidence=gpu_entries,
+            gpu_list=gpu_entries,
         )
 
         # gpu_vm_verify should have been called in sorted order: 0, 1, 2
@@ -423,8 +475,8 @@ class TestVmVerifyGpuEvidence:
         """GPU evidence without report_data_binding should not trigger GPU verify."""
         gpu_evidence = [
             {
-                "tee-type": "nvidia-hopper",
-                "tee-evidence": self.GPU_EVIDENCE_B64,
+                "type": "nvidia-hopper",
+                "evidence": self.GPU_EVIDENCE_B64,
                 "device-index": 0,
             },
         ]
@@ -442,7 +494,7 @@ class TestVmVerifyGpuEvidence:
                 self.KEY_ID,
                 wrapping_key=self.WRAPPING_KEY,
                 report_data_binding=False,
-                gpu_evidence=gpu_evidence,
+                gpu_list=gpu_evidence,
             )
 
             mock_gpu.assert_not_called()
@@ -461,7 +513,7 @@ class TestVmVerifyGpuEvidence:
             self.KEY_ID,
             wrapping_key=self.WRAPPING_KEY,
             report_data_binding=True,
-            gpu_evidence=None,
+            gpu_list=None,
         )
 
         mock_gpu.assert_not_called()
@@ -484,13 +536,13 @@ class TestVmVerifyGpuEvidence:
 
         gpu_evidence = [
             {
-                "tee-type": "t",
-                "tee-evidence": base64.b64encode(b"g0").decode(),
+                "type": "t",
+                "evidence": self._make_envelope(b"g0"),
                 "device-index": 0,
             },
             {
-                "tee-type": "t",
-                "tee-evidence": base64.b64encode(b"g1").decode(),
+                "type": "t",
+                "evidence": self._make_envelope(b"g1"),
                 "device-index": 1,
             },
         ]
@@ -503,7 +555,7 @@ class TestVmVerifyGpuEvidence:
             self.KEY_ID,
             wrapping_key=self.WRAPPING_KEY,
             report_data_binding=True,
-            gpu_evidence=gpu_evidence,
+            gpu_list=gpu_evidence,
         )
 
         assert ok is False


### PR DESCRIPTION
# Enable NVIDIA GPU attestation and component policies

## Summary

Adds optional **NVIDIA GPU attestation** to TAS. GPU evidence sent alongside a CPU TEE (SEV-SNP / TDX) request is verified via the NVIDIA Remote Attestation Service (NRAS), validated against a new top-level `components` policy section, and bound into the CPU `report_data`. GPU verification is delegated to [`nvidia_pytools`](https://github.com/TEE-Attestation/nvidia_pytools); if it isn't installed, GPU requests fail with an actionable error and CPU-only flows are unchanged.

## Changes

- **`tas/components/gpu_nvidia.py`** (new): adapter to `nvidia_pytools` with optional policy validation.
- **`tas/tas_vm.py`**: `vm_verify()` fetches the policy once, extracts `components.gpu`, verifies each GPU, and binds its evidence hash into `report_data` (ordered by `device-index`). `sev_vm_verify`/`tdx_vm_verify` reuse the pre-fetched policy and return `(is_verified, error)`.
- **`tas/client_routes.py`**: `get_secret` accepts a generic `component-evidence` object (`gpu` → `type` / `evidence` / `device-index`).
- **CI**: install `nvidia_pytools`.
- **Docs**: README (overview, platform support, install, GPU request example), `docs/POLICY.md` (Component Policies section), `docs/openapi.{yaml,json}` (`report-data-binding`, `ComponentEvidence`, `PolicyComponents`).
- **Tests**: GPU binding/ordering, policy resolution, requires-GPU enforcement.

## Enforcement

| Condition | Result |
|-----------|--------|
| Policy has `components.gpu` and GPU evidence supplied | GPUs verified + validated |
| Policy has `components.gpu`, no GPU evidence | Fail |
| GPU evidence, no `components.gpu` | Warn, verify without policy validation |
| Neither | CPU-only, unchanged |

## Policy format

```json
"components": {
  "gpu": {
    "gpu-nvidia": {
      "version": "4.0",
      "authorization-rules": {
        "type": "JWT",
        "overall-claims": { "x-nvidia-overall-att-result": true },
        "detached-claims": { "measres": "success", "dbgstat": "disabled", "secboot": true }
      }
    }
  }
}
```

## Request format

```json
"component-evidence": {
  "gpu": [ { "type": "gpu-nvidia", "evidence": "base64-envelope", "device-index": 0 } ]
}
```


Policies without `components` and requests without `component-evidence` are unaffected; `components` is signed by the existing RFC 8785 scheme.
