### PR TITLE
feat(mock kbm): enable optional SQLite-backed writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,5 @@ tas.log
 #VS Code settings
 .vscode/
 .github/copilot-instructions.md
+# Mock KBM SQLite database (plaintext mock secrets - never commit)
+config/kbm_db/

--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ secrets:
   test-key-1: "test-secret-value"
   another-key: "another-secret"
 ```
+See [here](./config/kbm_mock_config.yaml) on how to configure the Mock KBM.
 
 ### Creating Custom Plugins
 

--- a/config/kbm_mock_config.yaml
+++ b/config/kbm_mock_config.yaml
@@ -1,4 +1,96 @@
-strict: true         # if true, missing keys raise; defaults to True when a config file exists
-secrets:             # key_id -> plaintext secret (used as-is, no derivation)
+# =============================================================================
+# Mock KBM plugin configuration (plugins/tas_kbm_mock.py)
+# -----------------------------------------------------------------------------
+# The Mock KBM is a software-only Key Broker Module for development and testing.
+# DO NOT USE IN PRODUCTION -- secrets here are stored in plaintext.
+#
+# This file is passed to the plugin via TAS_KBM_CONFIG_FILE. All keys below are
+# optional; with an empty file the plugin runs the read-only in-memory backend.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# strict (optional, default: true when this config file is present)
+# -----------------------------------------------------------------------------
+#   true  : requesting an unknown key_id raises an error.
+#   false : a random secret is generated for unknown keys -- persisted on the
+#           sqlite backend, ephemeral on the file backend (see "Key generation").
+strict: true
+
+# -----------------------------------------------------------------------------
+# Storage backend (optional)
+# -----------------------------------------------------------------------------
+#   file   (default) : secrets from the `secrets:` map below, loaded read-only
+#                      into memory. Writes are rejected.
+#   sqlite (opt-in)  : secrets persisted in a local SQLite database file.
+#                      Write-enabled and safe across multiple worker processes.
+#
+# Selection precedence:
+#   1. backend: sqlite  -> SQLite
+#   2. backend: file    -> file/in-memory (even if db_path is set)
+#   3. backend unset    -> file/in-memory (default). A db_path on its own does
+#                          NOT select SQLite; set backend: sqlite explicitly.
+# An unrecognized backend value fails fast at startup.
+#
+# To enable local writes, uncomment the two lines below:
+#backend: sqlite
+#db_path: kbm_db/kbm_mock_secrets.db
+#
+# db_path notes:
+#   - Relative paths resolve against THIS config file's directory (not the
+#     process CWD), so the server and the CLI always agree on the same file.
+#   - When omitted, the default is kbm_db/kbm_mock_secrets.db next to this file.
+
+# -----------------------------------------------------------------------------
+# SQLite behavior
+# -----------------------------------------------------------------------------
+#   - Writes are create-only: writing an existing key_id is rejected (no
+#     overwrite, no delete).
+#   - The `secrets:` map below is IGNORED by the sqlite backend; it does not
+#     seed the database. Populate it explicitly via
+#     scripts/kbm_mock_secret_writer.py.
+#   - The DB files (`*.db`, `*.db-wal`, `*.db-shm`) hold plaintext mock secrets.
+#     They live under `config/kbm_db/` by default, which is gitignored; keep it
+#     private (e.g. `chmod 700 config/kbm_db`).
+#   - The DB directory and file MUST be owned by the user running TAS (and the
+#     writer CLI) and MUST NOT be symlinks. Initialization refuses to start on a
+#     group/world-accessible mode, foreign ownership, or a symlinked path rather
+#     than risk exposing plaintext secrets.
+#   - Removing a secret is intentionally NOT supported by the plugin or the CLI,
+#     so it cannot happen by accident. To delete a key, use the sqlite3 CLI
+#     directly:
+#       sqlite3 config/kbm_db/kbm_mock_secrets.db \
+#           "DELETE FROM secrets WHERE key_id='my-key-1';"
+#     Back up the DB first. NOTE: in non-strict mode a deleted key is
+#     re-provisioned (a new random secret) on the next request.
+#
+# Injecting secrets into the SQLite backend (scripts/kbm_mock_secret_writer.py):
+#   # single secret (from stdin, so it stays out of shell history)
+#   printf 's3cr3t' | python scripts/kbm_mock_secret_writer.py \
+#       --config config/kbm_mock_config.yaml --key-id my-key-3 --secret -
+#   # bulk import every entry from a YAML `secrets:` map
+#   python scripts/kbm_mock_secret_writer.py \
+#       --config config/kbm_mock_config.yaml --import config/kbm_mock_config.yaml
+
+# -----------------------------------------------------------------------------
+# Key generation (non-strict mode)
+# -----------------------------------------------------------------------------
+# When strict is false and a requested key_id is not found, the Mock KBM
+# generates a fresh random secret to satisfy the request. What happens to that
+# secret depends on the active backend:
+#   - file backend   : ephemeral -- never written back; a different value is
+#                      produced on every call.
+#   - sqlite backend : the generated secret is written back to the database and
+#                      returned, so the same key_id returns that stored value on
+#                      every later call. Concurrent first-time requests converge
+#                      on a single stored value (one writer wins).
+# strict=true is unaffected: a missing key_id always raises "Secret not found".
+
+# -----------------------------------------------------------------------------
+# Secrets (file backend only)
+# -----------------------------------------------------------------------------
+# Mapping of key_id -> secret. Values are used verbatim (UTF-8 bytes); strings
+# like "0xdeadbeef" or "ffeeddccbbaa" are NOT hex-decoded. Served by the FILE
+# backend only; the sqlite backend ignores this map.
+secrets:
     my-key-1: "0xdeadbeef"
-    my-key-2: "ffeeddccbbaa"   # kept as the exact string content, not decoded
+    my-key-2: "ffeeddccbbaa"   # kept as exact string content, not hex-decoded

--- a/plugins/tas_kbm_mock.py
+++ b/plugins/tas_kbm_mock.py
@@ -1,7 +1,7 @@
 #
 # TEE Attestation Service - Mock KBM (software, no KMIP)
 #
-# Copyright 2025 Hewlett Packard Enterprise Development LP.
+# Copyright 2025 - 2026 Hewlett Packard Enterprise Development LP.
 # SPDX-License-Identifier: MIT
 #
 # This file is part of the TEE Attestation Service.
@@ -12,7 +12,17 @@
 # - If a config file (YAML/JSON) provides `secrets`, they are used as-is.
 # - When a config file is present and no `strict` is specified, strict defaults to True
 #   so missing keys will NOT be derived (prevents implicit derivation from plaintext files).
-# - Returns: {"wrapped_key": b64, "blob": b64, "iv": b64}
+# - Returns: {"wrapped_key": b64, "blob": b64, "iv": b64, "tag": b64}
+#
+# Storage backends (selected via config, see kbm_open_client_connection):
+# - "file" (default): secrets are loaded from the config `secrets:` map into an
+#   in-memory dict. READ-ONLY -- writes are rejected.
+# - "sqlite" (opt-in): secrets are persisted in a local SQLite database file.
+#   WRITE-ENABLED and safe across multiple worker processes (create-only; no
+#   overwrite and no delete). The config `secrets:` map is NOT used to seed the
+#   database -- populated  explicitly via scripts/kbm_mock_secret_writer.py, for example. In
+#   non-strict + sqlite mode, secrets generated for unknown keys are persisted
+#   so the same key_id returns a stable value on later calls.
 
 from __future__ import annotations
 
@@ -20,13 +30,27 @@ import base64
 import json
 import os
 import secrets as _secrets
+import stat
 import threading
-from typing import Any, Dict, Optional
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 try:
     import yaml  # PyYAML (listed in requirements)
 except Exception:
     yaml = None
+
+if TYPE_CHECKING:
+    # For type checkers, sqlite3 is always needed so annotations like
+    # `sqlite3.Connection` resolve. At runtime it may be absent (below).
+    import sqlite3
+else:
+    try:
+        import sqlite3
+    except (
+        Exception
+    ):  # sqlite3 is a dev only requirment so may be absent in minimal builds
+        sqlite3 = None
 
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import padding as sympadding
@@ -46,6 +70,27 @@ AES_KEY_LEN = 32  # AES-256
 IV_LEN = 12  # AES-GCM IV size
 SECRET_LEN = 32  # default secret length when derivation is allowed
 
+# SQLite backend defaults. The DB lives in a dedicated subdirectory (relative to
+# the config file's directory) so the three WAL artifacts stay isolated.
+DEFAULT_DB_DIRNAME = "kbm_db"
+DEFAULT_DB_FILENAME = "kbm_mock_secrets.db"
+
+# SQLite schema version, stored via `PRAGMA user_version`. Keep in sync with
+# scripts/kbm_mock_secret_writer.py (both read/write the same database file).
+SQLITE_SCHEMA_VERSION = 1
+
+# The plaintext mock secret DB (and its transient WAL/SHM sidecars) are protected
+# by owner-only *directory* permissions rather than per-file chmod: SQLite creates
+# the sidecars using the umask and deletes them when the last connection closes, so
+# per-file tightening is unreliable. A 0o700 parent dir blocks group/other from
+# every artifact; we create it 0o700 and refuse to run if it is more permissive.
+DB_DIR_MODE = 0o700
+
+# The DB file itself is tightened to owner-only (0o600) and verified at init; if
+# it stays group/world accessible we warn and stop rather than serve readable
+# secrets. The transient WAL/SHM sidecars remain protected by the directory.
+DB_FILE_MODE = 0o600
+
 
 def _b64(b: bytes) -> str:
     return base64.b64encode(b).decode("ascii")
@@ -62,35 +107,344 @@ def _load_rsa_public_key(raw: bytes):
         raise ValueError("Invalid RSA public key format") from e
 
 
-def _aes_gcm_encrypt(key: bytes, iv: bytes, plaintext: bytes) -> bytes:
+def _aes_gcm_encrypt(key: bytes, iv: bytes, plaintext: bytes) -> tuple[bytes, bytes]:
     cipher = Cipher(algorithms.AES(key), modes.GCM(iv))
     enc = cipher.encryptor()
     return enc.update(plaintext) + enc.finalize(), enc.tag
 
 
-class _MockKBMClient:
-    def __init__(self, strict: bool, secrets_map: Dict[str, bytes]):
-        self.strict = bool(strict)
+def _secret_to_bytes(v: Any) -> bytes:
+    """Normalize a secret value to bytes (same rules as config secret parsing)."""
+    if isinstance(v, bytes):
+        return v
+    if isinstance(v, bytearray):
+        return bytes(v)
+    if isinstance(v, str):
+        # Use as-is (plaintext), encoded to bytes
+        return v.encode("utf-8")
+    # For non-strings, store their compact JSON representation as bytes
+    return json.dumps(v, separators=(",", ":")).encode("utf-8")
+
+
+# Expected column layout for schema version 1. Used to reject a pre-existing but
+# incompatible ``secrets`` table before stamping ``PRAGMA user_version`` on a
+# foreign database. Maps column name -> (declared type upper-cased, notnull, pk).
+# In SQLite a non-INTEGER PRIMARY KEY column is not implicitly NOT NULL, so
+# key_id has notnull=0, pk=1; secret is NOT NULL; created_at is a plain column.
+_EXPECTED_SECRETS_COLUMNS = {
+    "key_id": ("TEXT", 0, 1),
+    "secret": ("BLOB", 1, 0),
+    "created_at": ("TEXT", 0, 0),
+}
+
+
+def _secrets_table_state(conn) -> str:
+    """Classify the ``secrets`` table as 'absent', 'compatible', or 'incompatible'.
+
+    Uses ``PRAGMA table_info(secrets)``, which returns an empty result set when
+    the table does not exist. Any deviation from the version-1 layout (missing,
+    extra, or mistyped columns, a wrong PRIMARY KEY, or a nullable secret column)
+    is reported as incompatible so the caller can fail fast rather than stamp
+    ``user_version`` onto a database this plugin did not create.
+    """
+    rows = conn.execute("PRAGMA table_info(secrets)").fetchall()
+    if not rows:
+        return "absent"
+    # rows: (cid, name, type, notnull, dflt_value, pk)
+    found = {
+        name: ((ctype or "").upper(), int(notnull), int(pk))
+        for _cid, name, ctype, notnull, _dflt, pk in rows
+    }
+    if set(found) != set(_EXPECTED_SECRETS_COLUMNS):
+        return "incompatible"
+    for name, (exp_type, exp_notnull, exp_pk) in _EXPECTED_SECRETS_COLUMNS.items():
+        act_type, act_notnull, act_pk = found[name]
+        if act_type != exp_type or act_notnull != exp_notnull:
+            return "incompatible"
+        # ``pk`` is the 1-based position in the primary key for members, else 0.
+        if bool(exp_pk) != bool(act_pk):
+            return "incompatible"
+    return "compatible"
+
+
+def _fs_owner_enforced() -> bool:
+    """Return True when POSIX owner/mode enforcement applies to this platform.
+
+    ``os.geteuid`` does not exist on Windows, where uid/mode semantics are not
+    reliable, so ownership checks are skipped there.
+    """
+    return os.name != "nt" and hasattr(os, "geteuid")
+
+
+def _ensure_private_db_dir(db_path: str) -> str:
+    """Ensure the SQLite DB sits in an owner-only directory; fail if it does not.
+
+    The plaintext mock secret DB and its transient WAL/SHM sidecars are protected
+    by *directory* permissions, not per-file chmod: SQLite creates the sidecars
+    with the process umask and deletes them when the last connection closes, so
+    per-file tightening is unreliable. A 0o700 parent directory blocks group/other
+    from every artifact.
+
+    The directory is created 0o700 when missing. If it already exists but is
+    group/world accessible, this warns and raises (fail-fast) instead of exposing
+    secrets. Returns the directory path.
+    """
+    parent = os.path.dirname(db_path) or "."
+    if not os.path.isdir(parent):
+        os.makedirs(parent, mode=DB_DIR_MODE, exist_ok=True)
+        try:
+            os.chmod(parent, DB_DIR_MODE)
+        except OSError:
+            pass
+    if os.path.islink(parent):
+        logger.error(f"SQLite DB directory {parent} is a symlink; refusing to use it")
+        raise ValueError(
+            f"Refusing to use SQLite DB directory {parent!r}: it is a symbolic link."
+        )
+    st = os.stat(parent)
+    mode = stat.S_IMODE(st.st_mode)
+    if mode & 0o077:
+        logger.error(
+            f"SQLite DB directory {parent} is too permissive (mode {oct(mode)}); "
+            "plaintext secrets would be readable by group/other"
+        )
+        raise ValueError(
+            f"Refusing to use SQLite DB directory {parent!r}: mode {oct(mode)} is "
+            f"group/world accessible. Restrict it (e.g. `chmod 700 {parent}`)."
+        )
+    if _fs_owner_enforced() and st.st_uid != os.geteuid():
+        logger.error(
+            f"SQLite DB directory {parent} is owned by uid {st.st_uid}, not the "
+            "current user; plaintext secrets could be exposed to another owner"
+        )
+        raise ValueError(
+            f"Refusing to use SQLite DB directory {parent!r}: owned by uid "
+            f"{st.st_uid}, expected effective uid {os.geteuid()}."
+        )
+    return parent
+
+
+def _ensure_db_file_private(db_path: str) -> None:
+    """Ensure the SQLite DB file is owner-only (0o600); warn and stop otherwise.
+
+    Complements the private-directory check. sqlite3.connect() creates the file
+    with the process umask (often 0o644), so it is tightened to 0o600 and then
+    verified. If the file is still group/world accessible, fail fast rather than
+    serving plaintext secrets from a readable file.
+    """
+    if not os.path.exists(db_path):
+        return
+    if os.path.islink(db_path):
+        logger.error(f"SQLite DB file {db_path} is a symlink; refusing to use it")
+        raise ValueError(
+            f"Refusing to use SQLite DB file {db_path!r}: it is a symbolic link."
+        )
+    try:
+        os.chmod(db_path, DB_FILE_MODE)
+    except OSError as e:
+        logger.warning(f"Could not set {db_path} to {oct(DB_FILE_MODE)}: {e}")
+    st = os.stat(db_path)
+    mode = stat.S_IMODE(st.st_mode)
+    if mode & 0o077:
+        logger.error(
+            f"SQLite DB file {db_path} is too permissive (mode {oct(mode)}); "
+            "plaintext secrets would be readable by group/other"
+        )
+        raise ValueError(
+            f"Refusing to use SQLite DB file {db_path!r}: mode {oct(mode)} is "
+            f"group/world accessible. Restrict it (e.g. `chmod 600 {db_path}`)."
+        )
+    if _fs_owner_enforced() and st.st_uid != os.geteuid():
+        logger.error(
+            f"SQLite DB file {db_path} is owned by uid {st.st_uid}, not the "
+            "current user; plaintext secrets could be exposed to another owner"
+        )
+        raise ValueError(
+            f"Refusing to use SQLite DB file {db_path!r}: owned by uid "
+            f"{st.st_uid}, expected effective uid {os.geteuid()}."
+        )
+
+
+class _InMemoryStore:
+    """Read-only in-memory secret store backed by the config `secrets:` map."""
+
+    supports_write = False
+
+    def __init__(self, secrets_map: Dict[str, bytes]):
         self._secrets = dict(secrets_map)
         self._lock = threading.RLock()
+
+    def get(self, key_id: str) -> Optional[bytes]:
+        with self._lock:
+            return self._secrets.get(key_id)
+
+    def put(self, key_id: str, value: bytes) -> bool:
+        raise ValueError("write not supported by file backend")
+
+
+class _SQLiteStore:
+    """Write-enabled SQLite secret store.
+
+    Create-only: a duplicate key_id raises ValueError. Uses WAL journalling and a
+    busy timeout so concurrent writers (threads or processes) are serialized
+    safely.
+
+    Connections are short-lived (opened per operation) rather than cached on the
+    store, which is created once and reused across requests. This avoids two
+    documented hazards:
+      * Python's sqlite3 defaults to check_same_thread=True, so a Connection may
+        only be used by the thread that created it (otherwise ProgrammingError).
+        In the default "multi-thread" mode, threads "may share the module, but
+        not connections".
+        https://docs.python.org/3/library/sqlite3.html
+      * A SQLite connection must not cross a process boundary (e.g. inherited
+        over fork()); doing so causes locking problems and possible corruption.
+        https://www.sqlite.org/howtocorrupt.html  (2.7 "Carrying an open
+        database connection across a fork()")
+    Opening a fresh connection per operation sidesteps both.
+    """
+
+    supports_write = True
+
+    def __init__(self, db_path: str):
+        if sqlite3 is None:
+            raise RuntimeError(
+                "SQLite backend requested but Python's sqlite3 module is "
+                "unavailable; use the file backend (backend: file) or install/"
+                "rebuild Python with sqlite3 support."
+            )
+        self.db_path = db_path
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        # journal_mode=WAL is persistent database state, so it is set once during
+        # _init_db rather than on every connection. busy_timeout is a per-
+        # connection setting and must be applied each time.
+        conn = sqlite3.connect(self.db_path, timeout=5.0)
+        conn.execute("PRAGMA busy_timeout=5000")
+        return conn
+
+    def _init_db(self) -> None:
+        # Secrets are protected by an owner-only directory (see
+        # _ensure_private_db_dir); refuse to run if it is group/world accessible.
+        _ensure_private_db_dir(self.db_path)
+        conn = self._connect()
+        try:
+            # Persisted once for the DB file; harmless to re-assert on an
+            # existing WAL database.
+            conn.execute("PRAGMA journal_mode=WAL")
+            (version,) = conn.execute("PRAGMA user_version").fetchone()
+            if version == 0:
+                # Fresh or pre-versioning DB. Refuse to adopt a foreign or
+                # incompatible `secrets` table: validate its shape before
+                # stamping user_version, so we never silently mark a mismatched
+                # database as schema version 1.
+                state = _secrets_table_state(conn)
+                if state == "incompatible":
+                    raise ValueError(
+                        "Mock KBM SQLite database has an unversioned but "
+                        "incompatible 'secrets' table; refusing to use it. Point "
+                        "db_path at a fresh file or migrate it deliberately."
+                    )
+                if state == "absent":
+                    conn.execute(
+                        "CREATE TABLE secrets ("
+                        "key_id TEXT PRIMARY KEY, "
+                        "secret BLOB NOT NULL, "
+                        "created_at TEXT)"
+                    )
+                conn.execute(f"PRAGMA user_version = {SQLITE_SCHEMA_VERSION}")
+                conn.commit()
+            elif version > SQLITE_SCHEMA_VERSION:
+                raise ValueError(
+                    f"Mock KBM SQLite schema version {version} is newer than "
+                    f"supported {SQLITE_SCHEMA_VERSION}; upgrade the plugin"
+                )
+            elif version < SQLITE_SCHEMA_VERSION:
+                raise ValueError(
+                    f"Mock KBM SQLite schema version {version} predates supported "
+                    f"{SQLITE_SCHEMA_VERSION}; migration required"
+                )
+        finally:
+            conn.close()
+        # The DB file now exists; enforce owner-only (0o600) or stop.
+        _ensure_db_file_private(self.db_path)
+
+    def get(self, key_id: str) -> Optional[bytes]:
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT secret FROM secrets WHERE key_id = ?", (key_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+        if row is None or row[0] is None:
+            return None
+        return bytes(row[0])
+
+    def put(self, key_id: str, value: bytes) -> bool:
+        """Create-only insert. Raises ValueError if the key_id already exists."""
+        created_at = datetime.now(timezone.utc).isoformat()
+        conn = self._connect()
+        try:
+            conn.execute(
+                "INSERT INTO secrets (key_id, secret, created_at) VALUES (?, ?, ?)",
+                (key_id, sqlite3.Binary(value), created_at),
+            )
+            conn.commit()
+            return True
+        except sqlite3.IntegrityError as e:
+            # PRIMARY KEY conflict -> create-only violation
+            raise ValueError("Secret already exists") from e
+        finally:
+            conn.close()
+
+
+class _MockKBMClient:
+    def __init__(self, strict: bool, store):
+        self.strict = bool(strict)
+        self.store = store
         logger.debug(
-            f"Initialized mock KBM client with strict={strict} and {len(secrets_map)} pre-configured secrets"
+            f"Initialized mock KBM client with strict={self.strict}, "
+            f"backend={type(store).__name__}, "
+            f"write={getattr(store, 'supports_write', False)}"
         )
 
     def get_secret(self, key_id: str) -> bytes:
         logger.debug(f"Retrieving secret for key_id: {key_id}")
-        with self._lock:
-            if key_id in self._secrets:
-                logger.debug(f"Found pre-configured secret for key_id: {key_id}")
-                return self._secrets[key_id]
-            if self.strict:
-                logger.error(f"Secret not found for key_id: {key_id} (strict mode)")
-                raise ValueError("Secret not found")
-            # Derivation allowed only when not strict (no plaintext file mandate)
-            logger.debug(
-                f"Generating random secret for key_id: {key_id} (non-strict mode)"
-            )
-            return _secrets.token_bytes(SECRET_LEN)
+        value = self.store.get(key_id)
+        if value is not None:
+            logger.debug(f"Found stored secret for key_id: {key_id}")
+            return value
+        if self.strict:
+            logger.error(f"Secret not found for key_id: {key_id} (strict mode)")
+            raise ValueError("Secret not found")
+        # Non-strict mode: generate a random secret to satisfy the request.
+        logger.debug(f"Generating random secret for key_id: {key_id} (non-strict mode)")
+        generated = _secrets.token_bytes(SECRET_LEN)
+        if not getattr(self.store, "supports_write", False):
+            # Read-only backend (file): the generated secret is ephemeral and
+            # is never written back; a different value is produced each call.
+            return generated
+        # Write-enabled backend (sqlite): persist the generated secret so the
+        # same key_id returns a stable value on later calls (get-or-create).
+        try:
+            self.store.put(key_id, generated)
+            logger.debug(f"Persisted generated secret for key_id: {key_id}")
+            return generated
+        except ValueError:
+            # Lost a create race -> return the value the winning writer stored.
+            existing = self.store.get(key_id)
+            if existing is not None:
+                logger.debug(
+                    f"Concurrent create for key_id: {key_id}; returning stored value"
+                )
+                return existing
+            # The row vanished between the failed insert and this read (e.g. a
+            # concurrent manual delete). Do not hand back an unpersisted value
+            # that later calls could not reproduce.
+            logger.error(f"Secret for key_id {key_id} disappeared during get-or-create")
+            raise ValueError("Secret not found") from None
 
 
 def _load_config_file(config_file: Optional[str]) -> Dict[str, Any]:
@@ -139,18 +493,108 @@ def _secrets_map_from_config(cfg: Dict[str, Any]) -> Dict[str, bytes]:
         if not isinstance(k, str):
             logger.warning(f"Skipping non-string key: {k}")
             continue
-        if isinstance(v, bytes):
-            out[k] = v
-        elif isinstance(v, bytearray):
-            out[k] = bytes(v)
-        elif isinstance(v, str):
-            # Use as-is (plaintext), encoded to bytes
-            out[k] = v.encode("utf-8")
-        else:
-            # For non-strings, store their JSON representation as bytes
-            out[k] = json.dumps(v, separators=(",", ":")).encode("utf-8")
+        out[k] = _secret_to_bytes(v)
         logger.debug(f"Added secret for key: {k}")
     return out
+
+
+def _resolve_db_path(db_path: Optional[str], base_dir: str) -> str:
+    """Resolve the SQLite DB path.
+
+    Relative paths are resolved against ``base_dir`` (the config file's directory)
+    so the server and the CLI agree on the same file regardless of process CWD.
+    When ``db_path`` is not provided, a default under ``base_dir`` is used.
+    """
+    if db_path:
+        p = db_path if os.path.isabs(db_path) else os.path.join(base_dir, db_path)
+    else:
+        p = os.path.join(base_dir, DEFAULT_DB_DIRNAME, DEFAULT_DB_FILENAME)
+    return os.path.abspath(p)
+
+
+def _select_backend(cfg: Dict[str, Any]) -> str:
+    """Return 'file' or 'sqlite' based on config; raise on an invalid backend.
+
+    - explicit ``backend: sqlite`` or ``backend: file`` wins.
+    - ``backend`` unset -> 'file'. A ``db_path`` on its own does NOT select the
+      SQLite backend; it must be requested explicitly with ``backend: sqlite``.
+    """
+    backend = cfg.get("backend") if isinstance(cfg, dict) else None
+    if backend is None or str(backend).strip() == "":
+        return "file"
+    normalized = str(backend).strip().lower()
+    if normalized in ("file", "sqlite"):
+        return normalized
+    raise ValueError(
+        f"Invalid mock KBM backend: {backend!r} (expected 'file' or 'sqlite')"
+    )
+
+
+def _compute_strict(cfg: Dict[str, Any], config_present: Optional[bool] = None) -> bool:
+    # When a config file is present, default strict to True so missing keys are
+    # NOT silently derived (which would auto-generate and, on the SQLite backend,
+    # persist secrets for unknown keys). Only an explicit ``strict: false`` opts
+    # out. With no config file, default to False to keep the zero-config in-memory
+    # dev experience.
+    if not isinstance(cfg, dict):
+        return bool(config_present)
+    if config_present is None:
+        # Direct callers (e.g. tests) that pass a dict without a file signal:
+        # treat a non-empty dict as an implicit "config present".
+        config_present = bool(cfg)
+    if config_present:
+        return bool(cfg.get("strict", True))
+    return bool(cfg.get("strict", False))
+
+
+def _client_from_config(
+    cfg: Dict[str, Any],
+    base_dir: Optional[str] = None,
+    db_path_override: Optional[str] = None,
+    config_present: Optional[bool] = None,
+) -> "_MockKBMClient":
+    """Build a mock KBM client from a parsed config dict.
+
+    Used by kbm_open_client_connection. ``config_present`` records whether the
+    config actually came from a file on disk; it drives the ``strict`` default
+    (see _compute_strict). When ``db_path_override`` is given, the SQLite backend
+    is used -- but an explicit ``backend: file`` in the config is a contradiction
+    and raises ValueError rather than being silently overridden. The config
+    ``secrets:`` map is only used by the file backend; the SQLite backend is
+    populated exclusively via explicit writes (the standalone CLI
+    scripts/kbm_mock_secret_writer.py, which does not import this module).
+    """
+    if base_dir is None:
+        base_dir = os.getcwd()
+    if not isinstance(cfg, dict):
+        cfg = {}
+    strict = _compute_strict(cfg, config_present)
+
+    if db_path_override is not None:
+        explicit_backend = cfg.get("backend")
+        if (
+            explicit_backend is not None
+            and str(explicit_backend).strip().lower() == "file"
+        ):
+            raise ValueError(
+                "conflicting mock KBM configuration: a db_path override selects "
+                "the SQLite backend but config sets backend: file"
+            )
+        backend = "sqlite"
+        raw_db_path = db_path_override
+    else:
+        backend = _select_backend(cfg)
+        raw_db_path = cfg.get("db_path")
+
+    if backend == "sqlite":
+        db_path = _resolve_db_path(raw_db_path, base_dir)
+        store = _SQLiteStore(db_path)
+        logger.info(f"Mock KBM using SQLite backend (write-enabled) at {db_path}")
+        return _MockKBMClient(strict=strict, store=store)
+
+    store = _InMemoryStore(_secrets_map_from_config(cfg))
+    logger.info("Mock KBM using file/in-memory backend (read-only)")
+    return _MockKBMClient(strict=strict, store=store)
 
 
 def kbm_open_client_connection(config_file: str = None):
@@ -158,23 +602,29 @@ def kbm_open_client_connection(config_file: str = None):
     Initialize the mock KBM client.
 
     Config file (YAML or JSON) format (all optional):
-      strict: bool         # if true, missing keys raise; defaults to True when a config file exists
-      secrets:             # key_id -> plaintext secret (used as-is, no derivation)
+      strict: bool          # if true, missing keys raise; defaults to True when a config file exists
+      backend: file|sqlite  # storage backend; defaults to "file" (read-only)
+      db_path: <path>       # SQLite DB path, relative to this config file's directory;
+                            #   only used when `backend: sqlite` is set
+      secrets:              # key_id -> plaintext secret (file backend only; see below)
         my-key-1: "plain-text-secret"
         my-key-2: "ffeeddccbbaa"   # kept as the exact string content, not decoded
+
+    The "file" backend is read-only and serves the `secrets:` map above. The
+    "sqlite" backend is write-enabled (create-only; no overwrite and no delete)
+    and does NOT seed from the `secrets:` map -- populate it with
+    scripts/kbm_mock_secret_writer.py. In non-strict mode, kbm_get_secret
+    auto-provisions unknown keys and persists them (get-or-create).
     """
     logger.info("Initializing mock KBM client connection")
     cfg = _load_config_file(config_file)
-    secrets_map = _secrets_map_from_config(cfg)
-
-    # If a config file exists and strict not specified, default to True to avoid derivation
-    if cfg:
-        strict = bool(cfg.get("strict", True))
-    else:
-        strict = bool(cfg.get("strict", False)) if isinstance(cfg, dict) else False
-
-    logger.info(f"Mock KBM client initialized with strict={strict}")
-    return _MockKBMClient(strict=strict, secrets_map=secrets_map)
+    config_present = bool(config_file) and os.path.isfile(os.path.abspath(config_file))
+    base_dir = (
+        os.path.dirname(os.path.abspath(config_file)) if config_file else os.getcwd()
+    )
+    client = _client_from_config(cfg, base_dir=base_dir, config_present=config_present)
+    logger.info(f"Mock KBM client initialized with strict={client.strict}")
+    return client
 
 
 def kbm_close_client_connection(kmip_client) -> None:
@@ -184,7 +634,7 @@ def kbm_close_client_connection(kmip_client) -> None:
 
 def kbm_get_secret(kmip_client, key_id: str, wrapping_key: bytes):
     """
-    Return dict: {"wrapped_key": b64, "blob": b64, "iv": b64}
+    Return dict: {"wrapped_key": b64, "blob": b64, "iv": b64, "tag": b64}
     """
     logger.info(f"Mock KBM get_secret request for key_id: {key_id}")
 
@@ -206,7 +656,7 @@ def kbm_get_secret(kmip_client, key_id: str, wrapping_key: bytes):
     aes_key = _secrets.token_bytes(AES_KEY_LEN)
     iv = _secrets.token_bytes(IV_LEN)
 
-    logger.debug("Encrypting secret with AES-CBC")
+    logger.debug("Encrypting secret with AES-GCM")
     blob, tag = _aes_gcm_encrypt(aes_key, iv, secret)
 
     logger.debug("Wrapping AES key with RSA public key")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ known_third_party = ["sev_pytools", "tdx_pytools"]
 addopts = [
     "--import-mode=importlib",
 ]
+# Keep the repo root on sys.path so `from plugins import ...` resolves the same
+# way regardless of where pytest is launched (predictable CI, no per-env hacks).
+pythonpath = ["."]
 
 
 [project.optional-dependencies]

--- a/scripts/kbm_mock_secret_writer.py
+++ b/scripts/kbm_mock_secret_writer.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+#
+# TEE Attestation Service - Mock KBM local secret injector
+#
+# Copyright 2026 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# This file is part of the TEE Attestation Service.
+#
+# Self-contained CLI to inject secrets into the Mock KBM's SQLite database.
+# It intentionally does NOT import the tas_kbm_mock plugin, so it can run
+# standalone (e.g. copied to another host) without the TAS package on sys.path.
+# It writes the SAME schema the plugin uses; SQLITE_SCHEMA_VERSION (PRAGMA
+# user_version) must be kept in sync with plugins/tas_kbm_mock.py.
+#
+# Writes are create-only (an existing key_id is rejected -- no overwrite/delete)
+#
+# There is no delete/remove command by design (prevents accidental loss). To
+# remove a key, use sqlite3 directly, e.g.:
+#   sqlite3 config/kbm_db/kbm_mock_secrets.db "DELETE FROM secrets WHERE key_id='k';"
+#
+# Examples:
+#   # single secret via a config file that selects the sqlite backend
+#   python scripts/kbm_mock_secret_writer.py --config config/kbm_mock_config.yaml \
+#       --key-id my-key-1 --secret "0xdeadbeef"
+#
+# Prefer --secret - (stdin) or --secret-file for real material: a literal
+# --secret VALUE is visible in the process list (ps) and shell history.
+#
+#   # secret from stdin (keeps it out of shell history)
+#   printf '0xdeadbeef' | python scripts/kbm_mock_secret_writer.py \
+#       --db config/kbm_db/kbm_mock_secrets.db --key-id my-key-1 --secret -
+#
+#   # secret from a file
+#   python scripts/kbm_mock_secret_writer.py \
+#       --db config/kbm_db/kbm_mock_secrets.db --key-id my-key-1 --secret-file ./secret.bin
+#
+#   # bulk import every entry from a YAML `secrets:` map
+#   python scripts/kbm_mock_secret_writer.py --config config/kbm_mock_config.yaml \
+#       --import config/kbm_mock_config.yaml
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import sys
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+try:
+    import yaml  # PyYAML (optional; only needed for YAML config files)
+except Exception:
+    yaml = None
+
+if TYPE_CHECKING:
+    # For type checkers, sqlite3 is always the module so annotations like
+    # `sqlite3.Connection` resolve. At runtime it may be absent (below).
+    import sqlite3
+else:
+    try:
+        import sqlite3
+    except Exception:  # sqlite3 is stdlib but may be absent in minimal builds
+        sqlite3 = None
+
+# SQLite schema version (stored via `PRAGMA user_version`). MUST match
+# plugins/tas_kbm_mock.py so the plugin and this CLI interoperate on one DB file.
+SQLITE_SCHEMA_VERSION = 1
+
+# Expected column layout for schema version 1 (kept in sync with
+# plugins/tas_kbm_mock.py). Maps column name -> (declared type upper-cased,
+# notnull, pk). A non-INTEGER PRIMARY KEY is not implicitly NOT NULL in SQLite,
+# so key_id has notnull=0, pk=1; secret is NOT NULL; created_at is a plain column.
+_EXPECTED_SECRETS_COLUMNS = {
+    "key_id": ("TEXT", 0, 1),
+    "secret": ("BLOB", 1, 0),
+    "created_at": ("TEXT", 0, 0),
+}
+
+# The plaintext secret DB (and its transient WAL/SHM sidecars) are protected by
+# owner-only *directory* permissions rather than per-file chmod (SQLite recreates
+# the sidecars with the umask on each write). Created 0o700; refuse to run if the
+# directory is group/world accessible.
+DB_DIR_MODE = 0o700
+
+# The DB file itself is tightened to owner-only (0o600) and verified at init.
+DB_FILE_MODE = 0o600
+
+# Default SQLite location, relative to the config file's directory.
+DEFAULT_DB_DIRNAME = "kbm_db"
+DEFAULT_DB_FILENAME = "kbm_mock_secrets.db"
+
+
+# --------------------------------------------------------------------------
+# Config parsing (mirrors the plugin's semantics; kept local for standalone use)
+# --------------------------------------------------------------------------
+def _load_config_file(config_file: Optional[str]) -> Dict[str, Any]:
+    if not config_file:
+        return {}
+    path = os.path.abspath(config_file)
+    if not os.path.isfile(path):
+        raise SystemExit(f"error: config file not found: {path}")
+    _, ext = os.path.splitext(path.lower())
+    if ext in (".yaml", ".yml"):
+        if yaml is None:
+            raise SystemExit("error: PyYAML is required to read a YAML config file")
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    else:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f) or {}
+    if not isinstance(data, dict):
+        raise SystemExit(f"error: config file is not a mapping: {path}")
+    return data
+
+
+def _secret_to_bytes(v: Any) -> bytes:
+    """Normalize a secret value to bytes (matches the plugin's rules)."""
+    if isinstance(v, bytes):
+        return v
+    if isinstance(v, bytearray):
+        return bytes(v)
+    if isinstance(v, str):
+        return v.encode("utf-8")
+    return json.dumps(v, separators=(",", ":")).encode("utf-8")
+
+
+def _secrets_map_from_config(cfg: Dict[str, Any]) -> Dict[str, bytes]:
+    out: Dict[str, bytes] = {}
+    raw = cfg.get("secrets")
+    if not isinstance(raw, dict):
+        return out
+    for k, v in raw.items():
+        if isinstance(k, str):
+            out[k] = _secret_to_bytes(v)
+    return out
+
+
+def _resolve_db_path(db_path: Optional[str], base_dir: str) -> str:
+    if db_path:
+        p = db_path if os.path.isabs(db_path) else os.path.join(base_dir, db_path)
+    else:
+        p = os.path.join(base_dir, DEFAULT_DB_DIRNAME, DEFAULT_DB_FILENAME)
+    return os.path.abspath(p)
+
+
+# --------------------------------------------------------------------------
+# SQLite store (inlined; schema-versioned)
+# --------------------------------------------------------------------------
+def _secrets_table_state(conn) -> str:
+    """Classify the ``secrets`` table as 'absent', 'compatible', or 'incompatible'.
+
+    Mirrors the plugin's check so the standalone CLI refuses to adopt a foreign
+    or incompatible unversioned database before stamping ``PRAGMA user_version``.
+    """
+    rows = conn.execute("PRAGMA table_info(secrets)").fetchall()
+    if not rows:
+        return "absent"
+    # rows: (cid, name, type, notnull, dflt_value, pk)
+    found = {
+        name: ((ctype or "").upper(), int(notnull), int(pk))
+        for _cid, name, ctype, notnull, _dflt, pk in rows
+    }
+    if set(found) != set(_EXPECTED_SECRETS_COLUMNS):
+        return "incompatible"
+    for name, (exp_type, exp_notnull, exp_pk) in _EXPECTED_SECRETS_COLUMNS.items():
+        act_type, act_notnull, act_pk = found[name]
+        if act_type != exp_type or act_notnull != exp_notnull:
+            return "incompatible"
+        if bool(exp_pk) != bool(act_pk):
+            return "incompatible"
+    return "compatible"
+
+
+def _fs_owner_enforced() -> bool:
+    """Return True when POSIX owner/mode enforcement applies to this platform."""
+    return os.name != "nt" and hasattr(os, "geteuid")
+
+
+def _ensure_private_db_dir(db_path: str) -> None:
+    """Ensure the DB sits in an owner-only directory; fail fast if not.
+
+    The plaintext secret DB and its transient WAL/SHM sidecars are protected by
+    directory permissions (0o700), not per-file chmod: SQLite creates the sidecars
+    with the umask and removes them when the last connection closes, so per-file
+    tightening is unreliable. Created 0o700 when missing; a pre-existing group/
+    world accessible directory is rejected rather than exposing secrets.
+    """
+    parent = os.path.dirname(db_path) or "."
+    if not os.path.isdir(parent):
+        os.makedirs(parent, mode=DB_DIR_MODE, exist_ok=True)
+        try:
+            os.chmod(parent, DB_DIR_MODE)
+        except OSError:
+            pass
+    if os.path.islink(parent):
+        raise SystemExit(
+            f"error: SQLite DB directory {parent} is a symbolic link; refusing "
+            "to use it."
+        )
+    st = os.stat(parent)
+    mode = stat.S_IMODE(st.st_mode)
+    if mode & 0o077:
+        raise SystemExit(
+            f"error: SQLite DB directory {parent} has mode {oct(mode)}, which is "
+            "accessible to group/other and would expose plaintext secrets; "
+            f"restrict it (chmod 700 {parent}) and retry."
+        )
+    if _fs_owner_enforced() and st.st_uid != os.geteuid():
+        raise SystemExit(
+            f"error: SQLite DB directory {parent} is owned by uid {st.st_uid}, "
+            f"not the current user (uid {os.geteuid()}); refusing to use it."
+        )
+
+
+def _ensure_db_file_private(db_path: str) -> None:
+    """Ensure the DB file is owner-only (0o600); warn and stop otherwise."""
+    if not os.path.exists(db_path):
+        return
+    if os.path.islink(db_path):
+        raise SystemExit(
+            f"error: SQLite DB file {db_path} is a symbolic link; refusing to "
+            "use it."
+        )
+    try:
+        os.chmod(db_path, DB_FILE_MODE)
+    except OSError as e:
+        print(f"warning: could not set {db_path} to 0o600: {e}", file=sys.stderr)
+    st = os.stat(db_path)
+    mode = stat.S_IMODE(st.st_mode)
+    if mode & 0o077:
+        raise SystemExit(
+            f"error: SQLite DB file {db_path} has mode {oct(mode)}, which is "
+            "accessible to group/other and would expose plaintext secrets; "
+            f"restrict it (chmod 600 {db_path}) and retry."
+        )
+    if _fs_owner_enforced() and st.st_uid != os.geteuid():
+        raise SystemExit(
+            f"error: SQLite DB file {db_path} is owned by uid {st.st_uid}, not "
+            f"the current user (uid {os.geteuid()}); refusing to use it."
+        )
+
+
+class SecretDB:
+    """Create-only, schema-versioned SQLite writer for mock KBM secrets."""
+
+    def __init__(self, db_path: str):
+        if sqlite3 is None:
+            raise SystemExit(
+                "error: Python's sqlite3 module is unavailable; "
+                "this tool requires SQLite support."
+            )
+        self.db_path = db_path
+        _ensure_private_db_dir(db_path)
+        conn = self._connect()
+        try:
+            self._init_schema(conn)
+        finally:
+            conn.close()
+        _ensure_db_file_private(db_path)
+
+    def _connect(self) -> sqlite3.Connection:
+        # journal_mode=WAL is persistent DB state (set once in _init_schema);
+        # busy_timeout is per-connection.
+        conn = sqlite3.connect(self.db_path, timeout=5.0)
+        conn.execute("PRAGMA busy_timeout=5000")
+        return conn
+
+    def _init_schema(self, conn: sqlite3.Connection) -> None:
+        conn.execute("PRAGMA journal_mode=WAL")
+        (version,) = conn.execute("PRAGMA user_version").fetchone()
+        if version == 0:
+            # Fresh or pre-versioning DB. Refuse to adopt a foreign or
+            # incompatible `secrets` table: validate its shape before stamping
+            # user_version so a mismatched database is never marked version 1.
+            state = _secrets_table_state(conn)
+            if state == "incompatible":
+                raise SystemExit(
+                    "error: SQLite database has an unversioned but incompatible "
+                    "'secrets' table; refusing to use it. Point --db at a fresh "
+                    "file or migrate it deliberately."
+                )
+            if state == "absent":
+                conn.execute(
+                    "CREATE TABLE secrets ("
+                    "key_id TEXT PRIMARY KEY, secret BLOB NOT NULL, created_at TEXT)"
+                )
+            conn.execute(f"PRAGMA user_version = {SQLITE_SCHEMA_VERSION}")
+            conn.commit()
+        elif version > SQLITE_SCHEMA_VERSION:
+            raise SystemExit(
+                f"error: database schema version {version} is newer than supported "
+                f"{SQLITE_SCHEMA_VERSION}; upgrade this tool"
+            )
+        elif version < SQLITE_SCHEMA_VERSION:
+            raise SystemExit(
+                f"error: database schema version {version} predates supported "
+                f"{SQLITE_SCHEMA_VERSION}; migration required"
+            )
+
+    def put(self, key_id: str, value: bytes) -> None:
+        """Create-only insert. Raises ValueError if the key_id already exists."""
+        created_at = datetime.now(timezone.utc).isoformat()
+        conn = self._connect()
+        try:
+            conn.execute(
+                "INSERT INTO secrets (key_id, secret, created_at) VALUES (?, ?, ?)",
+                (key_id, sqlite3.Binary(value), created_at),
+            )
+            conn.commit()
+        except sqlite3.IntegrityError as e:
+            raise ValueError("Secret already exists") from e
+        finally:
+            conn.close()
+
+
+# --------------------------------------------------------------------------
+# Target resolution + commands
+# --------------------------------------------------------------------------
+def _db_path_from_args(args) -> str:
+    if args.db:
+        return _resolve_db_path(args.db, os.getcwd())
+
+    cfg = _load_config_file(args.config)
+    backend = str(cfg.get("backend") or "").strip().lower()
+    if backend not in ("", "file", "sqlite"):
+        raise SystemExit(f"error: invalid backend {backend!r} in {args.config}")
+    if backend != "sqlite":
+        raise SystemExit(
+            "error: the selected config does not enable the SQLite backend.\n"
+            "       Set `backend: sqlite` in the config, or pass --db PATH."
+        )
+    base_dir = os.path.dirname(os.path.abspath(args.config))
+    return _resolve_db_path(cfg.get("db_path"), base_dir)
+
+
+def _read_single_secret(args) -> bytes:
+    if args.secret is not None:
+        if args.secret == "-":
+            return sys.stdin.buffer.read()
+        return args.secret.encode("utf-8")
+    if args.secret_file is not None:
+        with open(args.secret_file, "rb") as f:
+            return f.read()
+    raise SystemExit(
+        "error: provide one of --secret, --secret-file, or --secret - (stdin)"
+    )
+
+
+def _do_single(db: SecretDB, args) -> int:
+    value = _read_single_secret(args)
+    if not value:
+        raise SystemExit("error: refusing to store an empty secret")
+    try:
+        db.put(args.key_id, value)
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+    print(f"stored secret for key_id: {args.key_id}")
+    return 0
+
+
+def _do_import(db: SecretDB, args) -> int:
+    cfg = _load_config_file(args.import_file)
+    secrets_map = _secrets_map_from_config(cfg)
+    if not secrets_map:
+        print(f"no secrets found in {args.import_file}", file=sys.stderr)
+        return 1
+    added, skipped = 0, 0
+    for key_id, value in secrets_map.items():
+        try:
+            db.put(key_id, value)
+            added += 1
+            print(f"added: {key_id}")
+        except ValueError:
+            skipped += 1
+            print(f"skipped (exists): {key_id}")
+    print(f"import complete: {added} added, {skipped} skipped")
+    return 0
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Inject secrets into the Mock KBM SQLite database (create-only).",
+    )
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument(
+        "--config", help="Mock KBM config file selecting the sqlite backend"
+    )
+    target.add_argument(
+        "--db", help="Explicit SQLite DB path (writes directly to this file)"
+    )
+
+    parser.add_argument("--key-id", help="Key id for a single secret write")
+    parser.add_argument(
+        "--secret",
+        help="Secret value; use '-' to read from stdin. NOTE: a literal value "
+        "is visible in the process list and shell history -- prefer '-' "
+        "(stdin) or --secret-file for real material.",
+    )
+    parser.add_argument("--secret-file", help="Read the secret value from this file")
+    parser.add_argument(
+        "--import",
+        dest="import_file",
+        help="Bulk import every entry from a YAML/JSON `secrets:` map",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.import_file and (args.key_id or args.secret or args.secret_file):
+        parser.error("--import cannot be combined with --key-id/--secret/--secret-file")
+    if not args.import_file and not args.key_id:
+        parser.error("provide --key-id (single write) or --import FILE (bulk)")
+    if sum(x is not None for x in (args.secret, args.secret_file)) > 1:
+        parser.error("use only one of --secret or --secret-file")
+
+    db = SecretDB(_db_path_from_args(args))
+
+    if args.import_file:
+        return _do_import(db, args)
+    return _do_single(db, args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_kbm_mock_sqlite.py
+++ b/tests/test_kbm_mock_sqlite.py
@@ -1,0 +1,665 @@
+#
+# TEE Attestation Service - Mock KBM SQLite backend tests.
+#
+# Copyright 2026 Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: MIT
+#
+# This file is part of the TEE Attestation Service.
+#
+
+"""Tests for the Mock KBM optional SQLite backend and create-only writes."""
+
+import base64
+import multiprocessing
+import os
+import subprocess
+import sys
+import threading
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding as ap
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+from plugins import tas_kbm_mock as kbm
+
+
+def _sqlite_client(tmp_path, secrets=None, strict=True):
+    cfg = {"backend": "sqlite", "db_path": "kbm_db/secrets.db", "strict": strict}
+    if secrets:
+        cfg["secrets"] = secrets
+    return kbm._client_from_config(cfg, base_dir=str(tmp_path))
+
+
+def _seed(client, key_id, value):
+    """White-box helper: store a known secret straight through the backend store.
+
+    kbm_put_secret was removed from the plugin's public surface (it was never
+    part of the KBM contract). The only write paths are kbm_get_secret's
+    get-or-create side effect and the standalone CLI, so tests that need a
+    specific stored value write directly to client.store.
+    """
+    return client.store.put(key_id, kbm._secret_to_bytes(value))
+
+
+# --------------------------------------------------------------------------
+# Backend selection / precedence
+# --------------------------------------------------------------------------
+
+
+def test_default_backend_is_file_readonly(tmp_path):
+    client = kbm._client_from_config({"secrets": {"k": "v"}}, base_dir=str(tmp_path))
+    assert type(client.store).__name__ == "_InMemoryStore"
+    assert client.store.supports_write is False
+    assert client.get_secret("k") == b"v"
+
+
+def test_explicit_file_backend_wins_over_db_path(tmp_path):
+    client = kbm._client_from_config(
+        {"backend": "file", "db_path": "kbm_db/x.db"}, base_dir=str(tmp_path)
+    )
+    assert type(client.store).__name__ == "_InMemoryStore"
+
+
+def test_db_path_alone_does_not_select_sqlite(tmp_path):
+    # db_path without an explicit `backend: sqlite` must NOT select SQLite; it
+    # falls back to the default read-only file/in-memory backend.
+    client = kbm._client_from_config({"db_path": "kbm_db/x.db"}, base_dir=str(tmp_path))
+    assert type(client.store).__name__ == "_InMemoryStore"
+
+
+def test_explicit_sqlite_backend(tmp_path):
+    client = _sqlite_client(tmp_path)
+    assert type(client.store).__name__ == "_SQLiteStore"
+    assert client.store.supports_write is True
+    assert (tmp_path / "kbm_db" / "secrets.db").is_file()
+
+
+def test_invalid_backend_raises(tmp_path):
+    with pytest.raises(ValueError, match="Invalid mock KBM backend"):
+        kbm._client_from_config({"backend": "postgres"}, base_dir=str(tmp_path))
+
+
+def test_db_path_override_conflicts_with_explicit_file_backend(tmp_path):
+    # A db_path override selects SQLite; an explicit `backend: file` contradicts
+    # it and must fail fast rather than being silently overridden.
+    with pytest.raises(ValueError, match="conflicting mock KBM configuration"):
+        kbm._client_from_config(
+            {"backend": "file"},
+            base_dir=str(tmp_path),
+            db_path_override=str(tmp_path / "kbm_db" / "x.db"),
+        )
+
+
+def test_db_path_override_ignores_unset_backend(tmp_path):
+    # Without an explicit `backend`, the override just selects SQLite.
+    client = kbm._client_from_config({}, db_path_override=str(tmp_path / "x.db"))
+    assert type(client.store).__name__ == "_SQLiteStore"
+
+
+# --------------------------------------------------------------------------
+# Write path (SQLite only)
+# --------------------------------------------------------------------------
+
+
+def test_file_backend_rejects_write(tmp_path):
+    client = kbm._client_from_config({"secrets": {"k": "v"}}, base_dir=str(tmp_path))
+    with pytest.raises(ValueError, match="write not supported"):
+        client.store.put("k2", b"x")
+
+
+def test_sqlite_write_then_read(tmp_path):
+    client = _sqlite_client(tmp_path)
+    assert _seed(client, "w1", "hello") is True
+    assert client.get_secret("w1") == b"hello"
+
+
+def test_sqlite_create_only_rejects_duplicate(tmp_path):
+    client = _sqlite_client(tmp_path)
+    _seed(client, "dup", "first")
+    with pytest.raises(ValueError, match="already exists"):
+        _seed(client, "dup", "second")
+    # original value preserved
+    assert client.get_secret("dup") == b"first"
+
+
+# --------------------------------------------------------------------------
+# The sqlite backend does not seed from the config `secrets:` map
+# --------------------------------------------------------------------------
+
+
+def test_sqlite_ignores_config_secrets(tmp_path):
+    # `secrets:` are only served by the file backend; sqlite must ignore them.
+    client = _sqlite_client(tmp_path, secrets={"seed": "abc"}, strict=True)
+    with pytest.raises(ValueError, match="Secret not found"):
+        client.get_secret("seed")
+
+
+def test_sqlite_persists_only_explicit_writes(tmp_path):
+    # A value written explicitly survives a reopen; config secrets never appear.
+    c1 = _sqlite_client(tmp_path, secrets={"cfg-only": "x"})
+    _seed(c1, "written", "value")
+    c2 = _sqlite_client(tmp_path, secrets={"cfg-only": "x"}, strict=False)
+    assert c2.get_secret("written") == b"value"
+    # config-only key was never seeded -> non-strict derivation yields random bytes
+    derived = c2.get_secret("cfg-only")
+    assert isinstance(derived, bytes) and len(derived) == kbm.SECRET_LEN
+
+
+# --------------------------------------------------------------------------
+# strict behavior
+# --------------------------------------------------------------------------
+
+
+def test_sqlite_strict_missing_raises(tmp_path):
+    client = _sqlite_client(tmp_path, strict=True)
+    with pytest.raises(ValueError, match="Secret not found"):
+        client.get_secret("nope")
+
+
+def test_sqlite_non_strict_derives(tmp_path):
+    client = _sqlite_client(tmp_path, strict=False)
+    val = client.get_secret("nope")
+    assert isinstance(val, bytes) and len(val) == kbm.SECRET_LEN
+
+
+def test_sqlite_non_strict_persists_generated_secret(tmp_path):
+    import sqlite3
+
+    client = _sqlite_client(tmp_path, strict=False)
+    first = client.get_secret("auto")
+    assert isinstance(first, bytes) and len(first) == kbm.SECRET_LEN
+    # Stable across calls (get-or-create).
+    assert client.get_secret("auto") == first
+    # Actually persisted in the DB.
+    db = tmp_path / "kbm_db" / "secrets.db"
+    row = (
+        sqlite3.connect(str(db))
+        .execute("SELECT secret FROM secrets WHERE key_id = ?", ("auto",))
+        .fetchone()
+    )
+    assert row is not None and bytes(row[0]) == first
+    # Survives a reopen of the same DB.
+    client2 = _sqlite_client(tmp_path, strict=False)
+    assert client2.get_secret("auto") == first
+
+
+def test_file_non_strict_is_ephemeral(tmp_path):
+    client = kbm._client_from_config(
+        {"strict": False, "secrets": {}}, base_dir=str(tmp_path)
+    )
+    assert type(client.store).__name__ == "_InMemoryStore"
+    assert client.get_secret("x") != client.get_secret("x")
+
+
+def test_empty_config_file_defaults_strict(tmp_path):
+    # A present-but-empty config file must default to strict=True so unknown keys
+    # are not silently derived (and, on sqlite, persisted).
+    cfg_file = tmp_path / "kbm.yaml"
+    cfg_file.write_text("")
+    client = kbm.kbm_open_client_connection(str(cfg_file))
+    assert client.strict is True
+
+
+def test_config_file_explicit_non_strict_opts_out(tmp_path):
+    cfg_file = tmp_path / "kbm.yaml"
+    cfg_file.write_text("strict: false\n")
+    client = kbm.kbm_open_client_connection(str(cfg_file))
+    assert client.strict is False
+
+
+def test_no_config_file_defaults_non_strict():
+    # Zero-config (no file): keep the permissive in-memory dev default.
+    client = kbm.kbm_open_client_connection(None)
+    assert client.strict is False
+
+
+def test_concurrent_generation_converges(tmp_path):
+    client = _sqlite_client(tmp_path, strict=False)
+    values = []
+    barrier = threading.Barrier(8)
+
+    def worker():
+        barrier.wait()
+        values.append(client.get_secret("race"))
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # All racing readers converge on one persisted value.
+    assert len(set(values)) == 1
+
+
+# --------------------------------------------------------------------------
+# Concurrency: create-only under contention
+# --------------------------------------------------------------------------
+
+
+def test_concurrent_writers_same_key_one_winner(tmp_path):
+    client = _sqlite_client(tmp_path)
+    results = []
+    barrier = threading.Barrier(8)
+
+    def worker():
+        barrier.wait()
+        try:
+            client.store.put("race", b"v")
+            results.append("ok")
+        except ValueError:
+            results.append("dup")
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert results.count("ok") == 1
+    assert results.count("dup") == 7
+
+
+def test_concurrent_distinct_keys_all_persist(tmp_path):
+    client = _sqlite_client(tmp_path)
+    barrier = threading.Barrier(10)
+
+    def worker(i):
+        barrier.wait()
+        client.store.put(f"k{i}", f"v{i}".encode())
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    for i in range(10):
+        assert client.get_secret(f"k{i}") == f"v{i}".encode()
+
+
+# --------------------------------------------------------------------------
+# Full get_secret unwrap round-trip
+# --------------------------------------------------------------------------
+
+
+def test_kbm_get_secret_unwrap_roundtrip(tmp_path):
+    client = _sqlite_client(tmp_path)
+    _seed(client, "wrapme", "top-secret")
+
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    res = kbm.kbm_get_secret(client, "wrapme", pub_pem)
+    aes_key = priv.decrypt(
+        base64.b64decode(res["wrapped_key"]),
+        ap.OAEP(mgf=ap.MGF1(hashes.SHA256()), algorithm=hashes.SHA256(), label=None),
+    )
+    dec = Cipher(
+        algorithms.AES(aes_key),
+        modes.GCM(base64.b64decode(res["iv"]), base64.b64decode(res["tag"])),
+    ).decryptor()
+    plaintext = dec.update(base64.b64decode(res["blob"])) + dec.finalize()
+    assert plaintext == b"top-secret"
+
+
+# --------------------------------------------------------------------------
+# Schema versioning + CLI interoperability
+# --------------------------------------------------------------------------
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_CLI = os.path.join(_REPO_ROOT, "scripts", "kbm_mock_secret_writer.py")
+
+
+def _user_version(db_path):
+    import sqlite3
+
+    return sqlite3.connect(str(db_path)).execute("PRAGMA user_version").fetchone()[0]
+
+
+def test_plugin_stamps_schema_version(tmp_path):
+    _sqlite_client(tmp_path)  # creates the DB
+    db = tmp_path / "kbm_db" / "secrets.db"
+    assert _user_version(db) == kbm.SQLITE_SCHEMA_VERSION
+
+
+def test_plugin_rejects_newer_schema_version(tmp_path):
+    import sqlite3
+
+    db = tmp_path / "kbm_db" / "secrets.db"
+    _sqlite_client(tmp_path)  # create at current version
+    conn = sqlite3.connect(str(db))
+    conn.execute(f"PRAGMA user_version = {kbm.SQLITE_SCHEMA_VERSION + 1}")
+    conn.commit()
+    conn.close()
+    with pytest.raises(ValueError, match="newer than supported"):
+        _sqlite_client(tmp_path)
+
+
+def test_cli_writes_plugin_readable_db(tmp_path):
+    # The self-contained CLI must produce a DB the plugin can read (same schema).
+    db = tmp_path / "kbm_db" / "secrets.db"
+    res = subprocess.run(
+        [
+            sys.executable,
+            _CLI,
+            "--db",
+            str(db),
+            "--key-id",
+            "cli-key",
+            "--secret",
+            "cli-val",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0, res.stderr
+    assert _user_version(db) == kbm.SQLITE_SCHEMA_VERSION
+    # Plugin reads the CLI-written value back.
+    client = kbm._client_from_config(
+        {"backend": "sqlite", "db_path": "kbm_db/secrets.db", "strict": True},
+        base_dir=str(tmp_path),
+    )
+    assert client.get_secret("cli-key") == b"cli-val"
+
+
+def test_cli_create_only_duplicate(tmp_path):
+    db = tmp_path / "kbm_db" / "secrets.db"
+    args = [sys.executable, _CLI, "--db", str(db), "--key-id", "dup", "--secret", "v"]
+    first = subprocess.run(args, capture_output=True, text=True)
+    assert first.returncode == 0, first.stderr
+    second = subprocess.run(args, capture_output=True, text=True)
+    assert second.returncode == 1
+    assert "already exists" in second.stderr
+
+
+# --------------------------------------------------------------------------
+# Multi-process writes (models gunicorn's separate worker processes)
+# --------------------------------------------------------------------------
+
+# gunicorn spawns worker *processes* (fork on Linux). These tests use real
+# processes -- each opening its OWN client/connection against one shared DB file
+# -- to exercise SQLite's cross-process file locking (not just threads).
+
+_FORK_AVAILABLE = "fork" in multiprocessing.get_all_start_methods()
+
+
+def _mp_put_worker(db_path, key_id, value, result_q):
+    """Runs in a separate process: open a fresh client and attempt one write."""
+    from plugins import tas_kbm_mock as kbm
+
+    client = kbm._client_from_config({}, db_path_override=db_path)
+    try:
+        client.store.put(key_id, kbm._secret_to_bytes(value))
+        result_q.put("ok")
+    except ValueError:
+        result_q.put("dup")
+
+
+@pytest.mark.skipif(
+    not _FORK_AVAILABLE,
+    reason="fork start method (gunicorn-style workers) unavailable on this platform",
+)
+def test_multiprocess_writers_same_key_one_winner(tmp_path):
+    ctx = multiprocessing.get_context("fork")
+    # Pre-create the DB + schema in the parent so workers race only on INSERT.
+    # (No open connection is inherited: the store opens/closes per operation.)
+    _sqlite_client(tmp_path)
+    db = str(tmp_path / "kbm_db" / "secrets.db")
+
+    result_q = ctx.Queue()
+    procs = [
+        ctx.Process(target=_mp_put_worker, args=(db, "shared", f"v{i}", result_q))
+        for i in range(6)
+    ]
+    for pr in procs:
+        pr.start()
+    for pr in procs:
+        pr.join(timeout=30)
+        assert pr.exitcode == 0
+
+    results = [result_q.get() for _ in procs]
+    assert results.count("ok") == 1
+    assert results.count("dup") == 5
+
+    # Exactly one row persisted for the contended key.
+    reader = _sqlite_client(tmp_path, strict=True)
+    assert reader.get_secret("shared") in {f"v{i}".encode() for i in range(6)}
+
+
+@pytest.mark.skipif(
+    not _FORK_AVAILABLE,
+    reason="fork start method (gunicorn-style workers) unavailable on this platform",
+)
+def test_multiprocess_distinct_keys_all_persist(tmp_path):
+    ctx = multiprocessing.get_context("fork")
+    _sqlite_client(tmp_path)
+    db = str(tmp_path / "kbm_db" / "secrets.db")
+
+    n = 8
+    result_q = ctx.Queue()
+    procs = [
+        ctx.Process(target=_mp_put_worker, args=(db, f"k{i}", f"v{i}", result_q))
+        for i in range(n)
+    ]
+    for pr in procs:
+        pr.start()
+    for pr in procs:
+        pr.join(timeout=30)
+        assert pr.exitcode == 0
+
+    results = [result_q.get() for _ in procs]
+    assert results.count("ok") == n
+
+    reader = _sqlite_client(tmp_path, strict=True)
+    for i in range(n):
+        assert reader.get_secret(f"k{i}") == f"v{i}".encode()
+
+
+# --------------------------------------------------------------------------
+# Graceful behavior when the sqlite3 module is unavailable
+# --------------------------------------------------------------------------
+
+
+def test_file_backend_works_without_sqlite3(monkeypatch):
+    # Simulate a minimal Python build lacking sqlite3. The default file backend
+    # must still import and work, since it never touches sqlite3.
+    monkeypatch.setattr(kbm, "sqlite3", None)
+    client = kbm._client_from_config({"strict": True, "secrets": {"k": "v"}})
+    assert type(client.store).__name__ == "_InMemoryStore"
+    assert client.get_secret("k") == b"v"
+
+
+def test_sqlite_backend_errors_clearly_without_sqlite3(tmp_path, monkeypatch):
+    monkeypatch.setattr(kbm, "sqlite3", None)
+    with pytest.raises(RuntimeError, match="sqlite3 module is"):
+        kbm._client_from_config(
+            {"backend": "sqlite", "db_path": "kbm_db/s.db"}, base_dir=str(tmp_path)
+        )
+
+
+# --------------------------------------------------------------------------
+# DB file permissions (plaintext mock secrets must not be group/world readable)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX directory mode bits only")
+def test_sqlite_db_dir_is_owner_only(tmp_path):
+    import stat
+
+    # A permissive umask must not leak into the DB directory perms; the
+    # owner-only directory is what protects the DB and its WAL/SHM sidecars.
+    old = os.umask(0o022)
+    try:
+        client = _sqlite_client(tmp_path)
+        _seed(client, "k", "v")
+    finally:
+        os.umask(old)
+    d = tmp_path / "kbm_db"
+    mode = stat.S_IMODE(d.stat().st_mode)
+    assert mode & 0o077 == 0, oct(mode)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file mode bits only")
+def test_sqlite_db_file_is_owner_only(tmp_path):
+    import stat
+
+    old = os.umask(0o022)
+    try:
+        client = _sqlite_client(tmp_path)
+        _seed(client, "k", "v")
+    finally:
+        os.umask(old)
+    db = tmp_path / "kbm_db" / "secrets.db"
+    # The DB file is tightened to owner-only despite the permissive umask.
+    assert stat.S_IMODE(db.stat().st_mode) & 0o077 == 0
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file mode bits only")
+def test_sqlite_rejects_group_readable_db_file(tmp_path, monkeypatch):
+    # Simulate a filesystem where chmod cannot tighten the file: init must warn
+    # and stop rather than serve a group/world-readable secret DB.
+    _sqlite_client(tmp_path)  # create a valid DB first
+    db = tmp_path / "kbm_db" / "secrets.db"
+    os.chmod(db, 0o644)
+    monkeypatch.setattr(kbm.os, "chmod", lambda *a, **k: None)
+    with pytest.raises(ValueError, match="permissive|mode"):
+        _sqlite_client(tmp_path)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX directory mode bits only")
+def test_sqlite_refuses_group_world_accessible_dir(tmp_path):
+    # A pre-existing, too-permissive DB directory must fail fast (warn + stop)
+    # rather than silently writing plaintext secrets where others can read them.
+    loose = tmp_path / "loose"
+    loose.mkdir()
+    os.chmod(loose, 0o755)
+    with pytest.raises(ValueError, match="permissive|mode"):
+        kbm._client_from_config(
+            {"backend": "sqlite", "db_path": "loose/s.db"}, base_dir=str(tmp_path)
+        )
+
+
+# ----------------------------------------------------------------------------
+# Schema validation: refuse to adopt an incompatible unversioned database
+# ----------------------------------------------------------------------------
+
+
+def _make_unversioned_db(tmp_path, create_sql):
+    """Create an owner-only kbm_db/secrets.db with user_version 0 and a custom
+    `secrets` table, returning the db path."""
+    import sqlite3
+
+    db_dir = tmp_path / "kbm_db"
+    db_dir.mkdir(mode=0o700)
+    db = db_dir / "secrets.db"
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.execute(create_sql)
+        conn.commit()
+    finally:
+        conn.close()
+    return db
+
+
+def _user_version_of(db):
+    import sqlite3
+
+    return sqlite3.connect(str(db)).execute("PRAGMA user_version").fetchone()[0]
+
+
+def test_sqlite_rejects_incompatible_unversioned_schema(tmp_path):
+    db = _make_unversioned_db(
+        tmp_path, "CREATE TABLE secrets (key_id TEXT PRIMARY KEY)"
+    )
+    with pytest.raises(ValueError, match="incompatible"):
+        _sqlite_client(tmp_path)
+    # The foreign DB must NOT be silently stamped as schema version 1.
+    assert _user_version_of(db) == 0
+
+
+def test_sqlite_adopts_compatible_unversioned_schema(tmp_path):
+    # A pre-existing table that exactly matches the v1 layout but was never
+    # stamped is adopted (stamped) and works.
+    db = _make_unversioned_db(
+        tmp_path,
+        "CREATE TABLE secrets ("
+        "key_id TEXT PRIMARY KEY, secret BLOB NOT NULL, created_at TEXT)",
+    )
+    client = _sqlite_client(tmp_path)
+    assert _user_version_of(db) == kbm.SQLITE_SCHEMA_VERSION
+    assert _seed(client, "k", "v") is True
+    assert client.get_secret("k") == b"v"
+
+
+def test_cli_rejects_incompatible_unversioned_schema(tmp_path):
+    import sqlite3
+
+    db = _make_unversioned_db(
+        tmp_path, "CREATE TABLE secrets (key_id TEXT PRIMARY KEY)"
+    )
+    res = subprocess.run(
+        [sys.executable, _CLI, "--db", str(db), "--key-id", "k", "--secret", "v"],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode != 0
+    assert "incompatible" in res.stderr
+    # Not stamped, and no row inserted.
+    assert _user_version_of(db) == 0
+    assert (
+        sqlite3.connect(str(db)).execute("SELECT count(*) FROM secrets").fetchone()[0]
+        == 0
+    )
+
+
+# ----------------------------------------------------------------------------
+# Filesystem trust: reject symlinks and wrong ownership (POSIX)
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics only")
+def test_sqlite_rejects_symlinked_db_dir(tmp_path):
+    realdir = tmp_path / "realdir"
+    realdir.mkdir(mode=0o700)
+    link = tmp_path / "kbm_db"
+    os.symlink(realdir, link, target_is_directory=True)
+    with pytest.raises(ValueError, match="symbolic link"):
+        _sqlite_client(tmp_path)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics only")
+def test_sqlite_rejects_symlinked_db_file(tmp_path):
+    db_dir = tmp_path / "kbm_db"
+    db_dir.mkdir(mode=0o700)
+    target = db_dir / "target.db"
+    link = db_dir / "secrets.db"
+    os.symlink(target, link)
+    with pytest.raises(ValueError, match="symbolic link"):
+        _sqlite_client(tmp_path)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX ownership semantics only")
+def test_sqlite_rejects_wrong_owner_dir(tmp_path, monkeypatch):
+    # Simulate a directory owned by a different user by making the effective uid
+    # differ from the (test-user-owned) directory's owner.
+    monkeypatch.setattr(kbm.os, "geteuid", lambda: os.getuid() + 1)
+    with pytest.raises(ValueError, match="owned by uid"):
+        _sqlite_client(tmp_path)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX ownership semantics only")
+def test_ensure_db_file_private_rejects_wrong_owner(tmp_path, monkeypatch):
+    # Build a valid DB first (owner == effective uid), then simulate a foreign
+    # owner and check the file-level trust helper in isolation.
+    client = _sqlite_client(tmp_path)
+    _seed(client, "k", "v")
+    db = tmp_path / "kbm_db" / "secrets.db"
+    monkeypatch.setattr(kbm.os, "geteuid", lambda: os.getuid() + 1)
+    with pytest.raises(ValueError, match="owned by uid"):
+        kbm._ensure_db_file_private(str(db))


### PR DESCRIPTION
Enable the Mock KBM to optionally persist secrets in a local SQLite database.

Before this change, the Mock KBM was effectively read-only. In non-strict mode it could generate a secret for a missing key_id, but that value was not persisted, so repeated requests for the same missing key_id returned different secrets.

This change improves the local development experience by:
- persisting automatically generated secrets in non-strict SQLite mode
- allowing manual secret injection through a standalone Python script
- keeping writes create-only, with duplicate key_id writes rejected

Deletion remains a manual operation by design to avoid accidental data loss. Usage is documented in config/kbm_mock_config.yaml.

SQLite safely handles concurrent writers across threads and processes because key_id is enforced as the PRIMARY KEY.