### PR TITLE
feat(cert-local): persist and validate local CA across restarts

### DIFF
--- a/config/cert_local_config.yaml
+++ b/config/cert_local_config.yaml
@@ -2,3 +2,16 @@
 # Do NOT use this generated CA in production!
 key_type: "EC"
 key_size: 384
+
+# Optional persisted local CA files. If all four files exist, tas_cert_local
+# loads and validates them. If none exist, it generates the root and
+# intermediate CA and writes them here for reuse after restart.
+#
+# WARNING: root_key_file and ca_key_file hold UNENCRYPTED CA private keys
+# (written with 0600 permissions). Store them on an encrypted volume, restrict
+# directory ownership to the TAS service account, and keep them out of shared
+# backups or version control. Use an HSM/KMS-backed CA for production.
+# root_key_file: "./certs/tas/local/root_ca.key"
+# root_cert_file: "./certs/tas/local/root_ca.crt"
+# ca_key_file: "./certs/tas/local/issuing_ca.key"
+# ca_cert_file: "./certs/tas/local/issuing_ca.crt"

--- a/docs/CERTIFY.md
+++ b/docs/CERTIFY.md
@@ -134,6 +134,24 @@ TAS uses the following configuration for its Certificate Issuance feature:
 - `TAS_CERT_PLUGIN` — Module name for the certificate signing backend (default: `tas_cert_local`).
 - `TAS_CERT_PLUGIN_PREFIX` — Plugin discovery prefix (default: `tas_cert`).
 - `TAS_CERT_CONFIG_FILE` — Configuration file path for the active cert plugin.
+  For `tas_cert_local`, this YAML file may define `root_key_file`,
+  `root_cert_file`, `ca_key_file`, and `ca_cert_file` to persist the local
+  root and intermediate CA across restarts or load an externally generated
+  CA hierarchy. When all four files exist, TAS loads and validates them;
+  when none exist, TAS generates and writes them; a partial set fails
+  startup. Concurrent generation is guarded by an exclusive lock file
+  (`.tas_cert_local.lock`) in the key directory. Loaded certificates must be
+  currently valid CA certificates with `keyCertSign`/`cRLSign` KeyUsage, the
+  intermediate must chain to the root, and near-expiry certificates log a
+  warning.
+
+  > **Warning:** These files include the CA private keys, which are written
+  > **unencrypted** (PKCS#8, no passphrase) with `0600` permissions. Protect
+  > them at rest: store them on an encrypted volume, restrict directory
+  > ownership to the TAS service account, keep them out of version control and
+  > backups that are not access-controlled, and prefer an HSM or KMS-backed CA
+  > for production. The bundled `tas_cert_local` plugin is intended for
+  > development and testing only.
 - `TAS_CERT_VALIDITY_SECONDS` — Lifespan of issued certificates in seconds (default: 300).
 - `TAS_CERT_CLOCK_SKEW_SECONDS` — Backdating offset to handle clock skew (default: 90).
 - `TAS_CERT_TRUST_DOMAIN` — Trust domain used for the URI SAN (default: `example.org`).

--- a/plugins/tas_cert_local.py
+++ b/plugins/tas_cert_local.py
@@ -7,13 +7,22 @@
 # This file is part of the TEE Attestation Service.
 #
 
+import contextlib
 import datetime
 import hashlib
-from typing import Any
+import os
+import tempfile
+from typing import Any, Iterator
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX platforms
+    fcntl = None  # type: ignore[assignment]
 
 import yaml
 from asn1crypto import x509 as x509_asn1
 from cryptography import x509
+from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.x509.oid import NameOID
@@ -30,6 +39,40 @@ _INT_PRIVATE_KEY: ec.EllipticCurvePrivateKey | None = None
 _INT_CERTIFICATE: x509.Certificate | None = None
 _CA_TRUST_DOMAIN = "example.org"
 _CA_SUBJECT_CN = f"ca.{_CA_TRUST_DOMAIN}"
+_CA_EXPIRY_WARNING_DAYS = 30
+_CA_PATH_KEYS = ("root_key_file", "root_cert_file", "ca_key_file", "ca_cert_file")
+_CA_LOCK_FILENAME = ".tas_cert_local.lock"
+
+
+@contextlib.contextmanager
+def _ca_file_lock(paths: dict[str, str]) -> Iterator[None]:
+    """Guard the check-then-act CA file sequence with an exclusive lock.
+
+    Prevents two concurrently starting TAS processes from racing on
+    generate-and-write, which could otherwise produce a partial or
+    inconsistent CA file set. Raises if advisory file locking is
+    unavailable on the platform.
+    """
+    lock_dir = os.path.dirname(paths["root_key_file"]) or "."
+    os.makedirs(lock_dir, exist_ok=True)
+    lock_path = os.path.join(lock_dir, _CA_LOCK_FILENAME)
+
+    if fcntl is None:  # pragma: no cover - non-POSIX platforms
+        raise RuntimeError(
+            "Advisory file locking is unavailable on this platform; refusing "
+            "to initialize persisted local CA files without a cross-process "
+            "guard"
+        )
+
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
 
 
 def _ca_key_usage() -> x509.KeyUsage:
@@ -47,40 +90,385 @@ def _ca_key_usage() -> x509.KeyUsage:
     )
 
 
+def _aware_utc(value: datetime.datetime) -> datetime.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=datetime.timezone.utc)
+    return value.astimezone(datetime.timezone.utc)
+
+
+def _not_valid_before(cert: x509.Certificate) -> datetime.datetime:
+    if hasattr(cert, "not_valid_before_utc"):
+        return cert.not_valid_before_utc
+    return _aware_utc(cert.not_valid_before)
+
+
+def _not_valid_after(cert: x509.Certificate) -> datetime.datetime:
+    if hasattr(cert, "not_valid_after_utc"):
+        return cert.not_valid_after_utc
+    return _aware_utc(cert.not_valid_after)
+
+
+def _ca_file_paths(cfg: dict[str, Any]) -> dict[str, str] | None:
+    paths = {key: cfg.get(key) for key in _CA_PATH_KEYS}
+    configured = {key: value for key, value in paths.items() if value}
+    if not configured:
+        return None
+    if len(configured) != len(_CA_PATH_KEYS):
+        missing = ", ".join(key for key in _CA_PATH_KEYS if not paths.get(key))
+        raise RuntimeError(
+            f"Incomplete local CA file configuration; missing: {missing}"
+        )
+    return {key: str(value) for key, value in paths.items()}
+
+
+def _generate_ca_hierarchy() -> None:
+    global _ROOT_PRIVATE_KEY, _ROOT_CERTIFICATE
+    global _INT_PRIVATE_KEY, _INT_CERTIFICATE
+
+    spiffe_san = x509.SubjectAlternativeName(
+        [x509.UniformResourceIdentifier(f"spiffe://{_CA_TRUST_DOMAIN}")]
+    )
+    now = datetime.datetime.now(datetime.timezone.utc)
+    not_after = now + datetime.timedelta(days=365)
+
+    # --- Root CA: self-signed, pathlen=1 (may issue exactly one CA below) ---
+    _ROOT_PRIVATE_KEY = ec.generate_private_key(ec.SECP384R1())
+    root_public_key = _ROOT_PRIVATE_KEY.public_key()
+    root_name = x509.Name(
+        [x509.NameAttribute(NameOID.COMMON_NAME, f"ca-root.{_CA_TRUST_DOMAIN}")]
+    )
+    _ROOT_CERTIFICATE = (
+        x509.CertificateBuilder()
+        .subject_name(root_name)
+        .issuer_name(root_name)
+        .public_key(root_public_key)
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(not_after)
+        .add_extension(x509.BasicConstraints(ca=True, path_length=1), critical=True)
+        .add_extension(_ca_key_usage(), critical=True)
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(root_public_key),
+            critical=False,
+        )
+        .add_extension(spiffe_san, critical=False)
+        .sign(_ROOT_PRIVATE_KEY, hashes.SHA512())
+    )
+
+    # --- Intermediate (issuing) CA: signed by root, pathlen=0 (leaves only) ---
+    _INT_PRIVATE_KEY = ec.generate_private_key(ec.SECP384R1())
+    int_public_key = _INT_PRIVATE_KEY.public_key()
+    int_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, _CA_SUBJECT_CN)])
+    _INT_CERTIFICATE = (
+        x509.CertificateBuilder()
+        .subject_name(int_name)
+        .issuer_name(root_name)
+        .public_key(int_public_key)
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(not_after)
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        .add_extension(_ca_key_usage(), critical=True)
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(int_public_key),
+            critical=False,
+        )
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(root_public_key),
+            critical=False,
+        )
+        .add_extension(spiffe_san, critical=False)
+        .sign(_ROOT_PRIVATE_KEY, hashes.SHA512())
+    )
+
+
+def _fsync_dir(path: str) -> None:
+    """Best-effort fsync of a directory so a rename/create is durable."""
+    try:
+        dir_fd = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(dir_fd)
+    except OSError:
+        pass
+    finally:
+        os.close(dir_fd)
+
+
+def _atomic_write_bytes(path: str, data: bytes, mode: int) -> None:
+    """Write bytes to path atomically via a same-directory temp file.
+
+    Readers observe either the previous complete file or the new complete
+    file, never a partially written one. The temp file is fsynced before the
+    rename, and the parent directory is fsynced afterward (best effort) so the
+    replacement survives a crash. The temp file is removed on any failure.
+    """
+    parent = os.path.dirname(path) or "."
+    os.makedirs(parent, exist_ok=True)
+
+    fd, tmp_path = tempfile.mkstemp(
+        dir=parent, prefix=f".{os.path.basename(path)}.", suffix=".tmp"
+    )
+    try:
+        os.chmod(tmp_path, mode)
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+        _fsync_dir(parent)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        raise
+
+
+def _write_private_key(path: str, key: ec.EllipticCurvePrivateKey) -> None:
+    _atomic_write_bytes(
+        path,
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+        mode=0o600,
+    )
+
+
+def _write_certificate(path: str, cert: x509.Certificate) -> None:
+    _atomic_write_bytes(path, cert.public_bytes(serialization.Encoding.PEM), mode=0o644)
+
+
+def _write_ca_files(paths: dict[str, str]) -> None:
+    if (
+        _ROOT_PRIVATE_KEY is None
+        or _ROOT_CERTIFICATE is None
+        or _INT_PRIVATE_KEY is None
+        or _INT_CERTIFICATE is None
+    ):
+        raise RuntimeError("Local CA is not initialized")
+
+    _write_private_key(paths["root_key_file"], _ROOT_PRIVATE_KEY)
+    _write_certificate(paths["root_cert_file"], _ROOT_CERTIFICATE)
+    _write_private_key(paths["ca_key_file"], _INT_PRIVATE_KEY)
+    _write_certificate(paths["ca_cert_file"], _INT_CERTIFICATE)
+
+
+def _load_private_key(path: str) -> ec.EllipticCurvePrivateKey:
+    with open(path, "rb") as f:
+        key = serialization.load_pem_private_key(f.read(), password=None)
+    if not isinstance(key, ec.EllipticCurvePrivateKey):
+        raise RuntimeError(f"Unsupported CA private key type in {path}; expected EC")
+    return key
+
+
+def _load_certificate(path: str) -> x509.Certificate:
+    with open(path, "rb") as f:
+        return x509.load_pem_x509_certificate(f.read())
+
+
+def _validate_key_certificate_pair(
+    label: str, key: ec.EllipticCurvePrivateKey, cert: x509.Certificate
+) -> None:
+    cert_public_key = cert.public_key()
+    if not isinstance(cert_public_key, ec.EllipticCurvePublicKey):
+        raise RuntimeError(f"Unsupported {label} CA certificate key type; expected EC")
+    if key.public_key().public_numbers() != cert_public_key.public_numbers():
+        raise RuntimeError(f"Loaded {label} CA private key does not match certificate")
+
+
+def _validate_certificate_validity(label: str, cert: x509.Certificate) -> None:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    not_before = _not_valid_before(cert)
+    not_after = _not_valid_after(cert)
+    if now < not_before:
+        raise RuntimeError(
+            f"Loaded {label} CA certificate is not valid before {not_before.isoformat()}"
+        )
+    if now > not_after:
+        raise RuntimeError(
+            f"Loaded {label} CA certificate expired at {not_after.isoformat()}"
+        )
+    warning_threshold = now + datetime.timedelta(days=_CA_EXPIRY_WARNING_DAYS)
+    if not_after <= warning_threshold:
+        days_remaining = (not_after - now).total_seconds() / 86400
+        logger.warning(
+            "Loaded %s CA certificate expires in %.1f days at %s",
+            label,
+            days_remaining,
+            not_after.isoformat(),
+        )
+
+
+def _validate_ca_basic_constraints(
+    label: str, cert: x509.Certificate, expected_path_length: int | None = None
+) -> None:
+    try:
+        bc_ext = cert.extensions.get_extension_for_class(x509.BasicConstraints)
+    except x509.ExtensionNotFound as exc:
+        raise RuntimeError(
+            f"Loaded {label} CA certificate is missing BasicConstraints"
+        ) from exc
+    if not bc_ext.value.ca:
+        raise RuntimeError(f"Loaded {label} CA certificate is not a CA")
+    if (
+        expected_path_length is not None
+        and bc_ext.value.path_length != expected_path_length
+    ):
+        raise RuntimeError(
+            f"Loaded {label} CA certificate must have path_length={expected_path_length}"
+        )
+    if (
+        label == "root"
+        and bc_ext.value.path_length is not None
+        and bc_ext.value.path_length < 1
+    ):
+        raise RuntimeError("Loaded root CA certificate must allow an intermediate CA")
+
+
+def _validate_ca_key_usage(label: str, cert: x509.Certificate) -> None:
+    try:
+        key_usage = cert.extensions.get_extension_for_class(x509.KeyUsage).value
+    except x509.ExtensionNotFound as exc:
+        raise RuntimeError(
+            f"Loaded {label} CA certificate is missing KeyUsage"
+        ) from exc
+    if not key_usage.key_cert_sign:
+        raise RuntimeError(
+            f"Loaded {label} CA certificate KeyUsage must include keyCertSign"
+        )
+    if not key_usage.crl_sign:
+        raise RuntimeError(
+            f"Loaded {label} CA certificate KeyUsage must include cRLSign"
+        )
+
+
+def _verify_certificate_signature(
+    label: str, issuer_cert: x509.Certificate, subject_cert: x509.Certificate
+) -> None:
+    issuer_public_key = issuer_cert.public_key()
+    if not isinstance(issuer_public_key, ec.EllipticCurvePublicKey):
+        raise RuntimeError(f"Unsupported {label} issuer key type; expected EC")
+    if subject_cert.signature_hash_algorithm is None:
+        raise RuntimeError(
+            f"Loaded {label} CA certificate signature algorithm is unsupported"
+        )
+    try:
+        issuer_public_key.verify(
+            subject_cert.signature,
+            subject_cert.tbs_certificate_bytes,
+            ec.ECDSA(subject_cert.signature_hash_algorithm),
+        )
+    except InvalidSignature as exc:
+        raise RuntimeError(
+            f"Loaded {label} CA certificate signature is invalid"
+        ) from exc
+
+
+def _validate_aki_matches_ski(
+    issuer_cert: x509.Certificate, subject_cert: x509.Certificate
+) -> None:
+    try:
+        aki = subject_cert.extensions.get_extension_for_class(
+            x509.AuthorityKeyIdentifier
+        ).value
+        ski = issuer_cert.extensions.get_extension_for_class(
+            x509.SubjectKeyIdentifier
+        ).value
+    except x509.ExtensionNotFound:
+        return
+    if aki.key_identifier and aki.key_identifier != ski.digest:
+        raise RuntimeError("Loaded intermediate CA AKI does not match root CA SKI")
+
+
+def _validate_loaded_ca(
+    root_key: ec.EllipticCurvePrivateKey,
+    root_cert: x509.Certificate,
+    int_key: ec.EllipticCurvePrivateKey,
+    int_cert: x509.Certificate,
+) -> None:
+    _validate_key_certificate_pair("root", root_key, root_cert)
+    _validate_key_certificate_pair("intermediate", int_key, int_cert)
+    _validate_certificate_validity("root", root_cert)
+    _validate_certificate_validity("intermediate", int_cert)
+    _validate_ca_basic_constraints("root", root_cert)
+    _validate_ca_basic_constraints("intermediate", int_cert, expected_path_length=0)
+    _validate_ca_key_usage("root", root_cert)
+    _validate_ca_key_usage("intermediate", int_cert)
+    if root_cert.subject != root_cert.issuer:
+        raise RuntimeError("Loaded root CA certificate is not self-issued")
+    if int_cert.issuer != root_cert.subject:
+        raise RuntimeError(
+            "Loaded intermediate CA certificate issuer does not match root subject"
+        )
+    _verify_certificate_signature("root", root_cert, root_cert)
+    _verify_certificate_signature("intermediate", root_cert, int_cert)
+    _validate_aki_matches_ski(root_cert, int_cert)
+
+
+def _load_ca_files(paths: dict[str, str]) -> None:
+    global _ROOT_PRIVATE_KEY, _ROOT_CERTIFICATE
+    global _INT_PRIVATE_KEY, _INT_CERTIFICATE
+
+    root_key = _load_private_key(paths["root_key_file"])
+    root_cert = _load_certificate(paths["root_cert_file"])
+    int_key = _load_private_key(paths["ca_key_file"])
+    int_cert = _load_certificate(paths["ca_cert_file"])
+    _validate_loaded_ca(root_key, root_cert, int_key, int_cert)
+    _ROOT_PRIVATE_KEY = root_key
+    _ROOT_CERTIFICATE = root_cert
+    _INT_PRIVATE_KEY = int_key
+    _INT_CERTIFICATE = int_cert
+
+
 def cert_open_client_connection(
     config_file: str | None = None, trust_domain: str | None = None
 ) -> str:
-    """Initialize the local ephemeral root+intermediate CA and return a handle.
+    """Initialize the local root+intermediate CA and return a handle.
 
-    Builds a self-signed root CA (pathlen=1) that signs an intermediate issuing
-    CA (pathlen=0). The intermediate is the issuer for all leaf certificates.
+    Builds or loads a self-signed root CA (pathlen=1) that signs an intermediate
+    issuing CA (pathlen=0). The intermediate is the issuer for all leaf
+    certificates.
 
     Args:
-        config_file: Optional YAML config path containing `ca_subject_cn` and `ca_trust_domain`.
-        trust_domain: Optional trust domain (e.g. from TAS_CERT_TRUST_DOMAIN). Takes
-            precedence over the YAML `ca_trust_domain` value when provided.
+        config_file: Optional YAML config path containing `ca_subject_cn`,
+            `ca_trust_domain`, and optional persisted CA file paths.
+        trust_domain: Optional trust domain (e.g. from TAS_CERT_TRUST_DOMAIN).
+            Takes precedence over the YAML `ca_trust_domain` value when provided.
 
     Returns:
         A static local client handle identifier.
     """
-    global _ROOT_PRIVATE_KEY, _ROOT_CERTIFICATE
-    global _INT_PRIVATE_KEY, _INT_CERTIFICATE
     global _CA_SUBJECT_CN, _CA_TRUST_DOMAIN
 
     explicit_cn = False
+    cfg: dict[str, Any] = {}
 
     if config_file:
         try:
             with open(config_file, "r", encoding="utf-8") as f:
-                cfg = yaml.safe_load(f)
-                if isinstance(cfg, dict):
-                    if "ca_trust_domain" in cfg:
-                        _CA_TRUST_DOMAIN = cfg["ca_trust_domain"]
-                    if "ca_subject_cn" in cfg:
-                        _CA_SUBJECT_CN = cfg["ca_subject_cn"]
-                        explicit_cn = True
-        except Exception:
-            pass
+                loaded_cfg = yaml.safe_load(f)
+        except OSError as exc:
+            raise RuntimeError(
+                f"Unable to read cert plugin config file {config_file}: {exc}"
+            ) from exc
+        except yaml.YAMLError as exc:
+            raise RuntimeError(
+                f"Unable to parse cert plugin config file {config_file}: {exc}"
+            ) from exc
+
+        if loaded_cfg is not None and not isinstance(loaded_cfg, dict):
+            raise RuntimeError(
+                f"Cert plugin config file {config_file} must contain a YAML mapping"
+            )
+        if isinstance(loaded_cfg, dict):
+            cfg = loaded_cfg
+            if "ca_trust_domain" in cfg:
+                _CA_TRUST_DOMAIN = cfg["ca_trust_domain"]
+            if "ca_subject_cn" in cfg:
+                _CA_SUBJECT_CN = cfg["ca_subject_cn"]
+                explicit_cn = True
 
     # Flask config (TAS_CERT_TRUST_DOMAIN) is the source of truth and overrides YAML.
     if trust_domain:
@@ -90,66 +478,40 @@ def cert_open_client_connection(
     if not explicit_cn:
         _CA_SUBJECT_CN = f"ca.{_CA_TRUST_DOMAIN}"
 
+    ca_paths = _ca_file_paths(cfg)
+
     logger.info("Initializing local root+intermediate CA")
     if config_file:
         logger.info("Loading cert plugin config from: %s", config_file)
 
     if _INT_PRIVATE_KEY is None:
-        spiffe_san = x509.SubjectAlternativeName(
-            [x509.UniformResourceIdentifier(f"spiffe://{_CA_TRUST_DOMAIN}")]
-        )
-        now = datetime.datetime.now(datetime.timezone.utc)
-        not_after = now + datetime.timedelta(days=365)
+        if ca_paths:
+            with _ca_file_lock(ca_paths):
+                # Re-check existence under the lock: another process may have
+                # generated the files while we waited to acquire it.
+                exists = {key: os.path.exists(path) for key, path in ca_paths.items()}
+                if all(exists.values()):
+                    _load_ca_files(ca_paths)
+                    logger.info(
+                        "Loaded local root+intermediate CA from configured files"
+                    )
+                elif not any(exists.values()):
+                    _generate_ca_hierarchy()
+                    _write_ca_files(ca_paths)
+                    logger.info("Generated and wrote local root+intermediate CA files")
+                else:
+                    missing = ", ".join(
+                        key
+                        for key, exists_for_key in exists.items()
+                        if not exists_for_key
+                    )
+                    raise RuntimeError(
+                        "Incomplete local CA file set; missing configured files for: "
+                        f"{missing}"
+                    )
+        else:
+            _generate_ca_hierarchy()
 
-        # --- Root CA: self-signed, pathlen=1 (may issue exactly one CA below) ---
-        _ROOT_PRIVATE_KEY = ec.generate_private_key(ec.SECP384R1())
-        root_public_key = _ROOT_PRIVATE_KEY.public_key()
-        root_name = x509.Name(
-            [x509.NameAttribute(NameOID.COMMON_NAME, f"ca-root.{_CA_TRUST_DOMAIN}")]
-        )
-        _ROOT_CERTIFICATE = (
-            x509.CertificateBuilder()
-            .subject_name(root_name)
-            .issuer_name(root_name)
-            .public_key(root_public_key)
-            .serial_number(x509.random_serial_number())
-            .not_valid_before(now)
-            .not_valid_after(not_after)
-            .add_extension(x509.BasicConstraints(ca=True, path_length=1), critical=True)
-            .add_extension(_ca_key_usage(), critical=True)
-            .add_extension(
-                x509.SubjectKeyIdentifier.from_public_key(root_public_key),
-                critical=False,
-            )
-            .add_extension(spiffe_san, critical=False)
-            .sign(_ROOT_PRIVATE_KEY, hashes.SHA512())
-        )
-
-        # --- Intermediate (issuing) CA: signed by root, pathlen=0 (leaves only) ---
-        _INT_PRIVATE_KEY = ec.generate_private_key(ec.SECP384R1())
-        int_public_key = _INT_PRIVATE_KEY.public_key()
-        int_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, _CA_SUBJECT_CN)])
-        _INT_CERTIFICATE = (
-            x509.CertificateBuilder()
-            .subject_name(int_name)
-            .issuer_name(root_name)
-            .public_key(int_public_key)
-            .serial_number(x509.random_serial_number())
-            .not_valid_before(now)
-            .not_valid_after(not_after)
-            .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
-            .add_extension(_ca_key_usage(), critical=True)
-            .add_extension(
-                x509.SubjectKeyIdentifier.from_public_key(int_public_key),
-                critical=False,
-            )
-            .add_extension(
-                x509.AuthorityKeyIdentifier.from_issuer_public_key(root_public_key),
-                critical=False,
-            )
-            .add_extension(spiffe_san, critical=False)
-            .sign(_ROOT_PRIVATE_KEY, hashes.SHA512())
-        )
         logger.info(
             "Local root+intermediate CA initialized with trust domain: %s",
             _CA_TRUST_DOMAIN,

--- a/tests/cert/test_cert_local_plugin.py
+++ b/tests/cert/test_cert_local_plugin.py
@@ -7,8 +7,15 @@
 # This file is part of the TEE Attestation Service.
 #
 
+import datetime
+import logging
+
 import pytest
 from asn1crypto import x509 as x509_asn1
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
 
 from plugins.tas_cert_local import (
     cert_get_ca_info,
@@ -154,3 +161,308 @@ def test_local_ca_root_intermediate_hierarchy(tmpdir):
         assert uris == ["spiffe://example.org"]
 
     cert_close_client_connection(client)
+
+
+def _reset_local_ca():
+    import plugins.tas_cert_local as cert_plugin_module
+
+    cert_plugin_module._ROOT_PRIVATE_KEY = None
+    cert_plugin_module._ROOT_CERTIFICATE = None
+    cert_plugin_module._INT_PRIVATE_KEY = None
+    cert_plugin_module._INT_CERTIFICATE = None
+
+
+def _persisted_ca_paths(tmp_path):
+    return {
+        "root_key_file": tmp_path / "root.key",
+        "root_cert_file": tmp_path / "root.crt",
+        "ca_key_file": tmp_path / "intermediate.key",
+        "ca_cert_file": tmp_path / "intermediate.crt",
+    }
+
+
+def _write_persisted_ca_config(tmp_path, paths=None):
+    paths = paths or _persisted_ca_paths(tmp_path)
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        "ca_trust_domain: example.org\n"
+        f"root_key_file: {paths['root_key_file']}\n"
+        f"root_cert_file: {paths['root_cert_file']}\n"
+        f"ca_key_file: {paths['ca_key_file']}\n"
+        f"ca_cert_file: {paths['ca_cert_file']}\n"
+    )
+    return config_file, paths
+
+
+def _write_key(path, key):
+    path.write_bytes(
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+
+
+def _write_cert(path, cert):
+    path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+
+
+def _load_key(path):
+    return serialization.load_pem_private_key(path.read_bytes(), password=None)
+
+
+def _load_cert(path):
+    return x509.load_pem_x509_certificate(path.read_bytes())
+
+
+def _name(common_name):
+    return x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+
+
+def _ca_key_usage_ext():
+    return x509.KeyUsage(
+        digital_signature=True,
+        content_commitment=False,
+        key_encipherment=False,
+        data_encipherment=False,
+        key_agreement=False,
+        key_cert_sign=True,
+        crl_sign=True,
+        encipher_only=False,
+        decipher_only=False,
+    )
+
+
+def _root_cert(root_key, not_before, not_after, ca=True, path_length=1):
+    root_public_key = root_key.public_key()
+    root_name = _name("ca-root.example.org")
+    return (
+        x509.CertificateBuilder()
+        .subject_name(root_name)
+        .issuer_name(root_name)
+        .public_key(root_public_key)
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .add_extension(x509.BasicConstraints(ca=ca, path_length=path_length), True)
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(root_public_key), False
+        )
+        .add_extension(_ca_key_usage_ext(), True)
+        .sign(root_key, hashes.SHA512())
+    )
+
+
+def _intermediate_cert(
+    intermediate_key,
+    issuer_key,
+    issuer_cert,
+    not_before,
+    not_after,
+    ca=True,
+    path_length=0,
+):
+    intermediate_public_key = intermediate_key.public_key()
+    return (
+        x509.CertificateBuilder()
+        .subject_name(_name("ca.example.org"))
+        .issuer_name(issuer_cert.subject)
+        .public_key(intermediate_public_key)
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .add_extension(x509.BasicConstraints(ca=ca, path_length=path_length), True)
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(intermediate_public_key), False
+        )
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(issuer_key.public_key()),
+            False,
+        )
+        .add_extension(_ca_key_usage_ext(), True)
+        .sign(issuer_key, hashes.SHA512())
+    )
+
+
+def test_local_ca_persists_and_reuses_configured_files(tmp_path):
+    _reset_local_ca()
+    config_file, paths = _write_persisted_ca_config(tmp_path)
+
+    cert_open_client_connection(str(config_file))
+    for path in paths.values():
+        assert path.is_file()
+
+    root_serial = _load_cert(paths["root_cert_file"]).serial_number
+    int_serial = _load_cert(paths["ca_cert_file"]).serial_number
+
+    _reset_local_ca()
+    cert_open_client_connection(str(config_file))
+
+    assert _load_cert(paths["root_cert_file"]).serial_number == root_serial
+    assert _load_cert(paths["ca_cert_file"]).serial_number == int_serial
+
+
+def test_local_ca_partial_file_set_raises(tmp_path):
+    _reset_local_ca()
+    config_file, paths = _write_persisted_ca_config(tmp_path)
+    paths["root_key_file"].write_text("partial")
+
+    with pytest.raises(RuntimeError, match="Incomplete local CA file set"):
+        cert_open_client_connection(str(config_file))
+
+
+def test_local_ca_rejects_key_certificate_mismatch(tmp_path):
+    _reset_local_ca()
+    config_file, paths = _write_persisted_ca_config(tmp_path)
+    cert_open_client_connection(str(config_file))
+
+    _reset_local_ca()
+    _write_key(paths["ca_key_file"], ec.generate_private_key(ec.SECP384R1()))
+
+    with pytest.raises(RuntimeError, match="private key does not match"):
+        cert_open_client_connection(str(config_file))
+
+
+def test_local_ca_rejects_expired_and_not_yet_valid_certificates(tmp_path):
+    _reset_local_ca()
+    config_file, paths = _write_persisted_ca_config(tmp_path)
+    cert_open_client_connection(str(config_file))
+
+    root_key = _load_key(paths["root_key_file"])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    expired_root = _root_cert(
+        root_key,
+        now - datetime.timedelta(days=2),
+        now - datetime.timedelta(days=1),
+    )
+    _write_cert(paths["root_cert_file"], expired_root)
+
+    _reset_local_ca()
+    with pytest.raises(RuntimeError, match="expired"):
+        cert_open_client_connection(str(config_file))
+
+    future_root = _root_cert(
+        root_key,
+        now + datetime.timedelta(days=1),
+        now + datetime.timedelta(days=2),
+    )
+    _write_cert(paths["root_cert_file"], future_root)
+
+    _reset_local_ca()
+    with pytest.raises(RuntimeError, match="not valid before"):
+        cert_open_client_connection(str(config_file))
+
+
+def test_local_ca_rejects_mismatched_chain(tmp_path):
+    _reset_local_ca()
+    config_file, paths = _write_persisted_ca_config(tmp_path)
+    cert_open_client_connection(str(config_file))
+
+    other_paths = _persisted_ca_paths(tmp_path / "other")
+    other_paths["root_key_file"].parent.mkdir()
+    other_config, other_paths = _write_persisted_ca_config(
+        tmp_path / "other", other_paths
+    )
+    _reset_local_ca()
+    cert_open_client_connection(str(other_config))
+
+    paths["root_key_file"].write_bytes(other_paths["root_key_file"].read_bytes())
+    paths["root_cert_file"].write_bytes(other_paths["root_cert_file"].read_bytes())
+
+    _reset_local_ca()
+    with pytest.raises(RuntimeError, match="signature is invalid|AKI"):
+        cert_open_client_connection(str(config_file))
+
+
+def test_local_ca_rejects_non_ca_certificate(tmp_path):
+    _reset_local_ca()
+    config_file, paths = _write_persisted_ca_config(tmp_path)
+    cert_open_client_connection(str(config_file))
+
+    root_key = _load_key(paths["root_key_file"])
+    root_cert = _load_cert(paths["root_cert_file"])
+    intermediate_key = _load_key(paths["ca_key_file"])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    non_ca = _intermediate_cert(
+        intermediate_key,
+        root_key,
+        root_cert,
+        now - datetime.timedelta(minutes=1),
+        now + datetime.timedelta(days=1),
+        ca=False,
+        path_length=None,
+    )
+    _write_cert(paths["ca_cert_file"], non_ca)
+
+    _reset_local_ca()
+    with pytest.raises(RuntimeError, match="not a CA"):
+        cert_open_client_connection(str(config_file))
+
+
+def test_local_ca_warns_on_near_expiry(tmp_path, caplog):
+    _reset_local_ca()
+    config_file, paths = _write_persisted_ca_config(tmp_path)
+    cert_open_client_connection(str(config_file))
+
+    root_key = _load_key(paths["root_key_file"])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    near_expiry_root = _root_cert(
+        root_key,
+        now - datetime.timedelta(minutes=1),
+        now + datetime.timedelta(days=1),
+    )
+    _write_cert(paths["root_cert_file"], near_expiry_root)
+
+    _reset_local_ca()
+    with caplog.at_level(logging.WARNING):
+        cert_open_client_connection(str(config_file))
+
+    assert "Loaded root CA certificate expires" in caplog.text
+
+
+def test_local_ca_rejects_missing_key_usage(tmp_path):
+    _reset_local_ca()
+    config_file, paths = _write_persisted_ca_config(tmp_path)
+    cert_open_client_connection(str(config_file))
+
+    root_key = _load_key(paths["root_key_file"])
+    root_cert = _load_cert(paths["root_cert_file"])
+    intermediate_key = _load_key(paths["ca_key_file"])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    # A valid CA cert (correct key, dates, BasicConstraints, signature) but
+    # without a KeyUsage extension must be rejected.
+    no_key_usage = (
+        x509.CertificateBuilder()
+        .subject_name(_name("ca.example.org"))
+        .issuer_name(root_cert.subject)
+        .public_key(intermediate_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=1))
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0), True)
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(intermediate_key.public_key()),
+            False,
+        )
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(root_key.public_key()),
+            False,
+        )
+        .sign(root_key, hashes.SHA512())
+    )
+    _write_cert(paths["ca_cert_file"], no_key_usage)
+
+    _reset_local_ca()
+    with pytest.raises(RuntimeError, match="KeyUsage"):
+        cert_open_client_connection(str(config_file))
+
+
+def test_local_ca_creates_lock_file(tmp_path):
+    _reset_local_ca()
+    config_file, paths = _write_persisted_ca_config(tmp_path)
+
+    cert_open_client_connection(str(config_file))
+
+    lock_path = tmp_path / ".tas_cert_local.lock"
+    assert lock_path.exists()


### PR DESCRIPTION
Prior to this commit, the CA certificates, including the root, was ephemeral and would be lost when the server was shut down. This was not very practical, even for development purposes.

This commit adds optional on-disk persistence for the root and intermediate CAs.