### PR TITLE
feat(certify): Enable issuing of certs with IP SANs and Email SANs

### DIFF
--- a/tas/cert/csr.py
+++ b/tas/cert/csr.py
@@ -10,6 +10,7 @@
 # according to strict policies. It ensures that CSRs are well-formed, contain valid proof of possession,
 # and adhere to allowed key types and subject name constraints.
 
+import ipaddress
 import re
 from typing import Optional, Sequence
 
@@ -18,8 +19,17 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.x509.oid import ExtensionOID, NameOID
 
+from ..tas_logging import get_logger
+
 # RFC 1035 / DNS-safe rough charset for CN: alphanumeric, dashes, dots.
 CN_CHARSET_RE = re.compile(r"^[a-zA-Z0-9.-]+$")
+EMAIL_LOCAL_PART_RE = re.compile(r"^[a-zA-Z0-9._+-]+$")
+MAX_DNS_SAN_ENTRIES = 16
+MAX_IP_SAN_ENTRIES = 8
+MAX_EMAIL_SAN_ENTRIES = 8
+MAX_INVALID_SAN_DEBUG_LOGS = 3
+
+logger = get_logger(__name__)
 
 
 def _is_dns_safe(value: str) -> bool:
@@ -46,12 +56,41 @@ def _is_dns_safe(value: str) -> bool:
     return True
 
 
+def _normalize_ip(value: object) -> str | None:
+    """Return a canonical textual IP address, or None for an invalid value."""
+    try:
+        return str(ipaddress.ip_address(value))
+    except ValueError:
+        return None
+
+
+def _is_email_safe(value: str) -> bool:
+    """Return True if value is a constrained, ASCII rfc822Name address."""
+    if not value.isascii() or len(value) > 254 or value.count("@") != 1:
+        return False
+    local_part, domain = value.split("@")
+    return (
+        bool(local_part)
+        and len(local_part) <= 64
+        and EMAIL_LOCAL_PART_RE.fullmatch(local_part) is not None
+        and not local_part.startswith(".")
+        and not local_part.endswith(".")
+        and ".." not in local_part
+        and _is_dns_safe(domain)
+    )
+
+
 def sanitize_csr(
     csr_bytes: bytes,
     allowed_key_types: Sequence[str],
     max_bytes: int = 10000,
 ) -> tuple[
-    rsa.RSAPublicKey | ec.EllipticCurvePublicKey, bytes, Optional[str], list[str]
+    rsa.RSAPublicKey | ec.EllipticCurvePublicKey,
+    bytes,
+    Optional[str],
+    list[str],
+    list[str],
+    list[str],
 ]:
     """Validate and sanitize a CSR for certificate issuance.
 
@@ -61,9 +100,9 @@ def sanitize_csr(
         max_bytes: Maximum accepted CSR size in bytes.
 
     Returns:
-        A tuple of (public_key, spki_der, subject_cn_or_none, dns_names) where
-        dns_names is a de-duplicated, order-preserving list of DNS-safe SAN
-        entries extracted from the CSR (empty when none are present/valid).
+        A tuple of (public_key, spki_der, subject_cn_or_none, dns_names,
+        ip_addresses, email_addresses). SAN lists are de-duplicated,
+        order-preserving, and contain only validated entries.
 
     Raises:
         ValueError: If the CSR is malformed or violates policy constraints.
@@ -121,21 +160,81 @@ def sanitize_csr(
             )
         subject_cn = cn_value
 
-    # Extract and sanitize dNSName SAN entries (optional, classic-TLS support).
-    # Invalid/unsafe entries (wildcards, IP literals, bad charset) are dropped.
+    # Extract and sanitize supported SAN types (optional, classic-TLS support).
     dns_names: list[str] = []
+    ip_addresses: list[str] = []
+    email_addresses: list[str] = []
+    seen_dns_names: set[str] = set()
+    seen_ip_addresses: set[str] = set()
+    seen_email_addresses: set[str] = set()
+    invalid_dns_values: list[str] = []
+    invalid_ip_values: list[str] = []
+    invalid_email_values: list[str] = []
     try:
         san_ext = csr.extensions.get_extension_for_oid(
             ExtensionOID.SUBJECT_ALTERNATIVE_NAME
         )
-        for dns_value in san_ext.value.get_values_for_type(x509.DNSName):
-            if (
-                isinstance(dns_value, str)
-                and _is_dns_safe(dns_value)
-                and dns_value not in dns_names
-            ):
-                dns_names.append(dns_value)
+        dns_values = san_ext.value.get_values_for_type(x509.DNSName)
+        if len(dns_values) > MAX_DNS_SAN_ENTRIES:
+            raise ValueError(
+                f"CSR contains too many DNS SAN entries (maximum {MAX_DNS_SAN_ENTRIES})"
+            )
+
+        for dns_value in dns_values:
+            if isinstance(dns_value, str) and _is_dns_safe(dns_value):
+                if dns_value not in seen_dns_names:
+                    seen_dns_names.add(dns_value)
+                    dns_names.append(dns_value)
+            else:
+                invalid_dns_values.append(str(dns_value))
+
+        ip_values = san_ext.value.get_values_for_type(x509.IPAddress)
+        if len(ip_values) > MAX_IP_SAN_ENTRIES:
+            raise ValueError(
+                f"CSR contains too many IP SAN entries (maximum {MAX_IP_SAN_ENTRIES})"
+            )
+
+        for ip_value in ip_values:
+            normalized_ip = _normalize_ip(ip_value)
+            if normalized_ip is None:
+                invalid_ip_values.append(str(ip_value))
+            elif normalized_ip not in seen_ip_addresses:
+                seen_ip_addresses.add(normalized_ip)
+                ip_addresses.append(normalized_ip)
+
+        email_values = san_ext.value.get_values_for_type(x509.RFC822Name)
+        if len(email_values) > MAX_EMAIL_SAN_ENTRIES:
+            raise ValueError(
+                f"CSR contains too many email SAN entries (maximum {MAX_EMAIL_SAN_ENTRIES})"
+            )
+
+        for email_value in email_values:
+            if isinstance(email_value, str) and _is_email_safe(email_value):
+                if email_value not in seen_email_addresses:
+                    seen_email_addresses.add(email_value)
+                    email_addresses.append(email_value)
+            else:
+                invalid_email_values.append(str(email_value))
     except x509.ExtensionNotFound:
         pass
 
-    return public_key, spki_der, subject_cn, dns_names
+    for san_type, invalid_values in (
+        ("DNS", invalid_dns_values),
+        ("IP", invalid_ip_values),
+        ("email", invalid_email_values),
+    ):
+        if invalid_values:
+            logger.warning(
+                "Dropped %d invalid %s SAN entries", len(invalid_values), san_type
+            )
+            for value in invalid_values[:MAX_INVALID_SAN_DEBUG_LOGS]:
+                logger.debug("Dropped invalid %s SAN value: %s", san_type, value)
+
+    return (
+        public_key,
+        spki_der,
+        subject_cn,
+        dns_names,
+        ip_addresses,
+        email_addresses,
+    )

--- a/tas/cert/issuer.py
+++ b/tas/cert/issuer.py
@@ -205,12 +205,14 @@ def build_tbs_der(
     ca_info: dict[str, Any],
     tas_exts: list[dict[str, Any]],
     dns_names: Sequence[str] | None = None,
+    ip_addresses: Sequence[str] | None = None,
+    email_addresses: Sequence[str] | None = None,
 ) -> x509.TbsCertificate:
     """Build an X.509 v3 TBS certificate object.
 
     This function sets SPIFFE/X509-SVID-friendly leaf extensions:
     - Subject Alternative Name with exactly one URI SAN (SPIFFE ID)
-    - Optional DNS SAN entries for classic TLS hostname verification
+    - Optional DNS, IP address, and email SAN entries for classic TLS use cases
     - Basic Constraints CA=false
     - Key Usage critical with digitalSignature
     - Extended Key Usage with clientAuth and serverAuth
@@ -226,6 +228,8 @@ def build_tbs_der(
         ca_info: Issuer metadata returned by cert plugin.
         tas_exts: TAS custom extension set.
         dns_names: Optional DNS SAN entries added alongside the single SPIFFE URI.
+        ip_addresses: Optional IP address SAN entries added alongside the SPIFFE URI.
+        email_addresses: Optional email SAN entries added alongside the SPIFFE URI.
 
     Returns:
         asn1crypto TbsCertificate object ready for external signing.
@@ -265,8 +269,8 @@ def build_tbs_der(
         }
     )
 
-    # URI SAN carries exactly one SPIFFE ID for leaf X509-SVID. Optional DNS
-    # SAN entries are added alongside it for classic TLS hostname verification.
+    # URI SAN carries exactly one SPIFFE ID for leaf X509-SVID. Optional DNS,
+    # IP address, and email SAN entries are added for classic TLS use cases.
     san_values: list[x509.GeneralName] = [
         x509.GeneralName({"uniform_resource_identifier": spiffe_uri})
     ]
@@ -276,6 +280,18 @@ def build_tbs_der(
             if name not in seen:
                 seen.add(name)
                 san_values.append(x509.GeneralName({"dns_name": name}))
+    if ip_addresses:
+        seen = set()
+        for address in ip_addresses:
+            if address not in seen:
+                seen.add(address)
+                san_values.append(x509.GeneralName({"ip_address": address}))
+    if email_addresses:
+        seen = set()
+        for address in email_addresses:
+            if address not in seen:
+                seen.add(address)
+                san_values.append(x509.GeneralName({"rfc822_name": address}))
     exts.append(
         {
             "extn_id": "subject_alt_name",

--- a/tas/cert/routes.py
+++ b/tas/cert/routes.py
@@ -146,9 +146,14 @@ def certify() -> tuple[Response, int]:
             "TAS_CERT_ALLOWED_KEY_TYPES", ["RSA", "EC"]
         )
         max_bytes = current_app.config.get("TAS_CERT_MAX_CSR_BYTES", 10000)
-        public_key, spki_der, subject_cn, dns_names = sanitize_csr(
-            csr_bytes, allowed_types, max_bytes
-        )
+        (
+            public_key,
+            spki_der,
+            subject_cn,
+            dns_names,
+            ip_addresses,
+            email_addresses,
+        ) = sanitize_csr(csr_bytes, allowed_types, max_bytes)
         ski_digest = x509.SubjectKeyIdentifier.from_public_key(public_key).digest
     except ValueError as e:
         logger.error(f"CSR sanitization failed: {e}")
@@ -256,6 +261,8 @@ def certify() -> tuple[Response, int]:
         ca_info,
         tas_exts,
         dns_names=dns_names,
+        ip_addresses=ip_addresses,
+        email_addresses=email_addresses,
     )
 
     try:

--- a/tests/cert/test_certify.py
+++ b/tests/cert/test_certify.py
@@ -8,6 +8,7 @@
 #
 
 import base64
+import ipaddress
 import json
 import os
 import shutil
@@ -17,6 +18,7 @@ from urllib.parse import urlsplit
 
 import pytest
 from asn1crypto import core
+from asn1crypto import x509 as asn1_x509
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 from cryptography.x509.oid import (
@@ -551,7 +553,14 @@ def test_certify_ca_chain_renders_with_openssl(test_client, monkeypatch):
         os_module.unlink(ca_pem_path)
 
 
-def _issue_leaf(test_client, monkeypatch, cn="chain-test.local", dns_names=None):
+def _issue_leaf(
+    test_client,
+    monkeypatch,
+    cn="chain-test.local",
+    dns_names=None,
+    ip_addresses=None,
+    email_addresses=None,
+):
     """Helper: drive a successful certify call and return the parsed JSON."""
     import tas.cert.routes as cert_routes
 
@@ -562,7 +571,12 @@ def _issue_leaf(test_client, monkeypatch, cn="chain-test.local", dns_names=None)
     )
 
     nonce = get_nonce(test_client)
-    csr_bytes = generate_csr(cn=cn, dns_names=dns_names)
+    csr_bytes = generate_csr(
+        cn=cn,
+        dns_names=dns_names,
+        ip_addresses=ip_addresses,
+        email_addresses=email_addresses,
+    )
     csr_b64 = base64.b64encode(csr_bytes).decode("ascii")
     payload = build_certify_payload(nonce, csr_b64)
 
@@ -958,3 +972,40 @@ def test_spiffe_rejects_invalid_leaves(test_client, monkeypatch):
     no_uri_pem, no_uri_key = _self_signed_leaf([x509.DNSName("plain.local")])
     with pytest.raises(InvalidLeafCertificateError):
         X509Svid.parse(no_uri_pem, no_uri_key)
+
+
+def test_certify_leaf_includes_csr_ip_and_email_sans(test_client, monkeypatch):
+    result = _issue_leaf(
+        test_client,
+        monkeypatch,
+        cn="mixed-sans.local",
+        ip_addresses=["192.0.2.10", "2001:db8::1"],
+        email_addresses=["service@example.com"],
+    )
+
+    leaf = x509.load_pem_x509_certificate(result["certificate"].encode("ascii"))
+    san = leaf.extensions.get_extension_for_oid(ExtensionOID.SUBJECT_ALTERNATIVE_NAME)
+
+    assert [
+        str(address) for address in san.value.get_values_for_type(x509.IPAddress)
+    ] == ["192.0.2.10", "2001:db8::1"]
+    assert san.value.get_values_for_type(x509.RFC822Name) == ["service@example.com"]
+
+    asn1_leaf = asn1_x509.Certificate.load(
+        leaf.public_bytes(serialization.Encoding.DER)
+    )
+    asn1_san = next(
+        extension
+        for extension in asn1_leaf["tbs_certificate"]["extensions"]
+        if extension["extn_id"].native == "subject_alt_name"
+    )
+    actual_ip_octets = [
+        general_name.chosen.contents
+        for general_name in asn1_san["extn_value"].parsed
+        if general_name.name == "ip_address"
+    ]
+    expected_ip_octets = [
+        ipaddress.ip_address(address).packed
+        for address in ("192.0.2.10", "2001:db8::1")
+    ]
+    assert actual_ip_octets == expected_ip_octets

--- a/tests/cert/test_csr_sanitization.py
+++ b/tests/cert/test_csr_sanitization.py
@@ -7,20 +7,36 @@
 # This file is part of the TEE Attestation Service.
 #
 
+import ipaddress
+import logging
+
 import pytest
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.x509.oid import NameOID
 
 from tas.cert.csr import sanitize_csr
 
 
-def generate_csr(cn=None, add_extension=False, dns_names=None, return_key=False):
-    private_key = rsa.generate_private_key(
-        public_exponent=65537,
-        key_size=3072,
-    )
+def generate_csr(
+    cn=None,
+    add_extension=False,
+    dns_names=None,
+    ip_addresses=None,
+    email_addresses=None,
+    return_key=False,
+    key_type="RSA",
+):
+    if key_type == "RSA":
+        private_key = rsa.generate_private_key(
+            public_exponent=65537,
+            key_size=3072,
+        )
+    elif key_type == "EC":
+        private_key = ec.generate_private_key(ec.SECP256R1())
+    else:
+        raise ValueError(f"Unsupported test key type: {key_type}")
     builder = x509.CertificateSigningRequestBuilder()
 
     name_attrs = []
@@ -35,6 +51,12 @@ def generate_csr(cn=None, add_extension=False, dns_names=None, return_key=False)
         san_entries.append(x509.DNSName("example.com"))
     if dns_names:
         san_entries.extend(x509.DNSName(name) for name in dns_names)
+    if ip_addresses:
+        san_entries.extend(
+            x509.IPAddress(ipaddress.ip_address(address)) for address in ip_addresses
+        )
+    if email_addresses:
+        san_entries.extend(x509.RFC822Name(address) for address in email_addresses)
     if san_entries:
         builder = builder.add_extension(
             x509.SubjectAlternativeName(san_entries),
@@ -53,9 +75,26 @@ def generate_csr(cn=None, add_extension=False, dns_names=None, return_key=False)
     return csr_pem
 
 
+@pytest.mark.parametrize(
+    ("key_type", "allowed_key_types", "expected_public_key_type"),
+    [
+        ("RSA", ["RSA"], rsa.RSAPublicKey),
+        ("EC", ["EC"], ec.EllipticCurvePublicKey),
+    ],
+)
+def test_csr_sanitization_accepts_supported_public_key_types(
+    key_type, allowed_key_types, expected_public_key_type
+):
+    csr_bytes = generate_csr(cn="valid-cn.com", key_type=key_type)
+
+    public_key, *_ = sanitize_csr(csr_bytes, allowed_key_types, 10000)
+
+    assert isinstance(public_key, expected_public_key_type)
+
+
 def test_csr_sanitization_valid():
     csr_bytes = generate_csr(cn="valid-cn.com")
-    pub, spki, cn, dns = sanitize_csr(csr_bytes, ["RSA"], 10000)
+    pub, spki, cn, dns, *_ = sanitize_csr(csr_bytes, ["RSA"], 10000)
     assert cn == "valid-cn.com"
     assert spki is not None
     assert dns == []
@@ -63,7 +102,7 @@ def test_csr_sanitization_valid():
 
 def test_csr_sanitization_no_cn():
     csr_bytes = generate_csr()
-    pub, spki, cn, dns = sanitize_csr(csr_bytes, ["RSA"], 10000)
+    pub, spki, cn, dns, *_ = sanitize_csr(csr_bytes, ["RSA"], 10000)
     assert cn is None
     assert dns == []
 
@@ -83,7 +122,7 @@ def test_csr_sanitization_invalid_cn_charset():
 def test_csr_sanitization_ignores_extensions():
     # The example.com DNS SAN is valid and extracted; other extensions ignored.
     csr_bytes = generate_csr(cn="valid", add_extension=True)
-    pub, spki, cn, dns = sanitize_csr(csr_bytes, ["RSA"], 10000)
+    pub, spki, cn, dns, *_ = sanitize_csr(csr_bytes, ["RSA"], 10000)
     assert cn == "valid"
     assert dns == ["example.com"]
 
@@ -92,7 +131,7 @@ def test_csr_sanitization_extracts_dns_sans():
     csr_bytes = generate_csr(
         cn="svc.local", dns_names=["svc.example.com", "api.example.com"]
     )
-    pub, spki, cn, dns = sanitize_csr(csr_bytes, ["RSA"], 10000)
+    pub, spki, cn, dns, *_ = sanitize_csr(csr_bytes, ["RSA"], 10000)
     assert cn == "svc.local"
     assert dns == ["svc.example.com", "api.example.com"]
 
@@ -101,7 +140,7 @@ def test_csr_sanitization_dedupes_dns_sans():
     csr_bytes = generate_csr(
         cn="svc.local", dns_names=["dup.example.com", "dup.example.com"]
     )
-    pub, spki, cn, dns = sanitize_csr(csr_bytes, ["RSA"], 10000)
+    pub, spki, cn, dns, *_ = sanitize_csr(csr_bytes, ["RSA"], 10000)
     assert dns == ["dup.example.com"]
 
 
@@ -110,11 +149,134 @@ def test_csr_sanitization_drops_unsafe_dns_sans():
         cn="svc.local",
         dns_names=["*.wildcard.example.com", "10.0.0.1", "good.example.com"],
     )
-    pub, spki, cn, dns = sanitize_csr(csr_bytes, ["RSA"], 10000)
+    pub, spki, cn, dns, *_ = sanitize_csr(csr_bytes, ["RSA"], 10000)
     assert dns == ["good.example.com"]
+
+
+@pytest.mark.parametrize(
+    "san_kwargs, san_type",
+    [
+        (
+            {"dns_names": [f"service-{index}.example.com" for index in range(17)]},
+            "DNS",
+        ),
+        (
+            {"ip_addresses": [f"192.0.2.{index}" for index in range(1, 10)]},
+            "IP",
+        ),
+        (
+            {"email_addresses": [f"service-{index}@example.com" for index in range(9)]},
+            "email",
+        ),
+    ],
+)
+def test_csr_sanitization_rejects_excessive_san_entries(san_kwargs, san_type):
+    csr_bytes = generate_csr(cn="svc.local", **san_kwargs)
+
+    with pytest.raises(ValueError, match=rf"too many {san_type} SAN entries"):
+        sanitize_csr(csr_bytes, ["RSA"], 10000)
 
 
 def test_csr_bad_size():
     csr_bytes = generate_csr()
     with pytest.raises(ValueError, match="exceeds maximum allowed size"):
         sanitize_csr(csr_bytes, ["RSA"], 100)  # strict 100 byte limit
+
+
+def test_csr_sanitization_extracts_ip_and_email_sans():
+    csr_bytes = generate_csr(
+        cn="svc.local",
+        ip_addresses=["192.0.2.10", "2001:db8::1", "192.0.2.10"],
+        email_addresses=["service@example.com", "service@example.com"],
+    )
+
+    _, _, _, _, ip_addresses, email_addresses = sanitize_csr(csr_bytes, ["RSA"], 10000)
+
+    assert ip_addresses == ["192.0.2.10", "2001:db8::1"]
+    assert email_addresses == ["service@example.com"]
+
+
+@pytest.mark.parametrize(
+    "email_address",
+    [
+        'quoted"local@example.com',
+        "bang!local@example.com",
+        "percent%local@example.com",
+        ".leading-dot@example.com",
+        "trailing-dot.@example.com",
+        "consecutive..dots@example.com",
+        f"{'a' * 65}@example.com",
+        f"{'a' * 64}@{'a' * 63}.{'b' * 63}.{'c' * 62}",
+    ],
+)
+def test_csr_sanitization_drops_unsafe_email_local_parts(email_address):
+    csr_bytes = generate_csr(cn="svc.local", email_addresses=[email_address])
+
+    _, _, _, _, _, email_addresses = sanitize_csr(csr_bytes, ["RSA"], 10000)
+
+    assert email_addresses == []
+
+
+def test_csr_sanitization_accepts_safe_email_local_part_at_length_limit():
+    email_address = f"{'a' * 64}@{'a' * 63}.{'b' * 63}.{'c' * 61}"
+    csr_bytes = generate_csr(cn="svc.local", email_addresses=[email_address])
+
+    _, _, _, _, _, email_addresses = sanitize_csr(csr_bytes, ["RSA"], 10000)
+
+    assert email_addresses == [email_address]
+
+
+def test_csr_sanitization_logs_invalid_san_counts(caplog):
+    csr_bytes = generate_csr(
+        cn="svc.local",
+        dns_names=["*.wildcard.example.com"],
+        email_addresses=["invalid@bad_domain", "valid@example.com"],
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="tas.cert.csr"):
+        _, _, _, dns_names, _, email_addresses = sanitize_csr(csr_bytes, ["RSA"], 10000)
+
+    assert dns_names == []
+    assert email_addresses == ["valid@example.com"]
+    warning_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+    ]
+    debug_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.DEBUG
+    ]
+    assert warning_messages == [
+        "Dropped 1 invalid DNS SAN entries",
+        "Dropped 1 invalid email SAN entries",
+    ]
+    assert all("wildcard" not in message for message in warning_messages)
+    assert all("invalid@bad_domain" not in message for message in warning_messages)
+    assert "Dropped invalid DNS SAN value: *.wildcard.example.com" in debug_messages
+    assert "Dropped invalid email SAN value: invalid@bad_domain" in debug_messages
+
+
+def test_csr_sanitization_caps_invalid_san_debug_logs(caplog):
+    invalid_dns_names = [f"*.invalid-{index}.example.com" for index in range(4)]
+    csr_bytes = generate_csr(cn="svc.local", dns_names=invalid_dns_names)
+
+    with caplog.at_level(logging.DEBUG, logger="tas.cert.csr"):
+        sanitize_csr(csr_bytes, ["RSA"], 10000)
+
+    warning_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+    ]
+    debug_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.DEBUG
+    ]
+
+    assert warning_messages == ["Dropped 4 invalid DNS SAN entries"]
+    assert debug_messages == [
+        f"Dropped invalid DNS SAN value: {name}" for name in invalid_dns_names[:3]
+    ]


### PR DESCRIPTION
Some users require the ability to request IP SANs and Email SANs via CSR. Added code to the certificate issuer to support issuing certificates with these SAN types.