### PR TITLE
Improvment: quickrun: Added log filepath, TLS SAN fix, and pytools relocation

### DIFF
--- a/scripts/quickrun.sh
+++ b/scripts/quickrun.sh
@@ -186,7 +186,7 @@ _clone_and_install() {
     local name=$1
     local url=$2
     local proxy=${3:-}
-    local dest="${PROJECT_DIR}/../${name}"
+    local dest="${QUICKRUN_DIR}/${name}"
 
     if [[ ! -d "${dest}" ]]; then
         info "Cloning ${name}..."
@@ -244,6 +244,7 @@ TAS_REDIS_PERSISTENCE: false
 TAS:
   logging:
     level: "INFO"
+    file: "./tas.log"
 YAML
     sed -i "s/PLACEHOLDER_PORT/${port}/g" "${QUICKRUN_DIR}/tas_config.yaml"
 }
@@ -278,6 +279,12 @@ _generate_tls_certificate() {
         else
             san="${san},DNS:${bind_host}"
         fi
+    else
+        # bind-all: include every non-loopback IP currently assigned to this host
+        while IFS= read -r _ip; do
+            [[ "$_ip" == "127.0.0.1" ]] && continue
+            san="${san},IP:${_ip}"
+        done < <(hostname -I | tr ' ' '\n' | grep -v '^$')
     fi
 
     # Step 4: Sign the server CSR with the CA


### PR DESCRIPTION
- Added Log File Location

Added a path/filename to logging to ensure that log file is created when running the script. Otherwise no log file is>
This change creates a tas.log inside the root of the tas directory.

- fix TLS IP SAN mismatch and keep pytools inside project

When the server binds to 0.0.0.0, the generated TLS certificate previously
only included IP:127.0.0.1 as a Subject Alternative Name. Clients connecting
via the server's external IP would get a certificate verify failed
(IP address mismatch) error. _generate_tls_certificate now enumerates all
non-loopback IPs via hostname -I and adds each as an IP: SAN. When a
specific IP is passed via --host, that IP is added directly as before.

- changed location of *_pytools when git cloned

sev_pytools, tdx_pytools, and nvidia_pytools were previously cloned to ../
(the parent of the project root), leaving stale directories outside the repo
that were never cleaned up by uninstall. They are now cloned into .quickrun/
alongside the venv and other build artifacts, so uninstall removes them.
